### PR TITLE
Restore original settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Then, you will see the main Hardentools window. It's very simple, you just click
 
 ![screenshot2](https://github.com/securitywithoutborders/hardentools/raw/master/graphics/screenshot2.png)
 
-In case you wish to restore the default settings and revert the changes Hardentools made (for example, if you need to use cmd.exe), you can simply re-run the tool and instead of an "Harden" button you will be prompted with a "Restore" button. Similarly, click it and wait for the modifications to be reverted.
+In case you wish to restore the original settings and revert the changes Hardentools made (for example, if you need to use cmd.exe), you can simply re-run the tool and instead of an "Harden" button you will be prompted with a "Restore" button. Similarly, click it and wait for the modifications to be reverted.
 
 In the future, we will create the ability to select or deselect certain modifications Hardentools is configured to make.
 

--- a/adobe.go
+++ b/adobe.go
@@ -43,13 +43,8 @@ func restore_adobe(pathRegEx string, value_name string) {
 	for _, adobe_version := range adobe_versions {
 		path := fmt.Sprintf(pathRegEx, adobe_version)
 		key, _ := registry.OpenKey(registry.CURRENT_USER, path, registry.ALL_ACCESS)
-		// retrieve saved state
-		value, err := retrieve_original_registry_DWORD(path, value_name)
-		if err == nil {
-			key.SetDWordValue(value_name, value)
-		} else {
-			key.DeleteValue(value_name)
-		}
+		// restore previous state
+		restore_key(key, path, value_name)
 		key.Close()
 	}
 }

--- a/adobe.go
+++ b/adobe.go
@@ -49,7 +49,6 @@ func restore_adobe(pathRegEx string, value_name string) {
 	}
 }
 
-
 /*
 bEnableJS possible values:
 0 - Disable AcroJS
@@ -61,12 +60,12 @@ func trigger_pdf_js(harden bool) {
 	var value_name = "bEnableJS"
 	var pathRegEx = "SOFTWARE\\Adobe\\Acrobat Reader\\%s\\JSPrefs"
 
-	if harden==false {
+	if harden == false {
 		events.AppendText("Restoring original settings for Acrobat Reader JavaScript\n")
 		restore_adobe(pathRegEx, value_name)
 	} else {
 		events.AppendText("Hardening by disabling Acrobat Reader JavaScript\n")
-		value = 0  // Disable AcroJS
+		value = 0 // Disable AcroJS
 		harden_adobe(pathRegEx, value_name, value)
 	}
 }
@@ -83,8 +82,8 @@ func trigger_pdf_objects(harden bool) {
 	var value_name_allow = "bAllowOpenFile"
 	var value_name_secure = "bSecureOpenFile"
 	var pathRegEx = "SOFTWARE\\Adobe\\Acrobat Reader\\%s\\Originals"
-	
-	if harden==false {
+
+	if harden == false {
 		events.AppendText("Restoring original settings for embedded objects in PDFs\n")
 		restore_adobe(pathRegEx, value_name_allow)
 		restore_adobe(pathRegEx, value_name_secure)

--- a/autorun.go
+++ b/autorun.go
@@ -26,27 +26,27 @@ import (
 - HKCU\Software\Microsoft\Windows\CurrentVersion\Policies\Explorer!NoDriveTypeAutoRun
 - HKCU\Software\Microsoft\Windows\CurrentVersion\Policies\Explorer!NoAutorun
 - HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\AutoplayHandlers!DisableAutoplay 1
- */
+*/
 func trigger_autorun(harden bool) {
 	var key_autorun_name = "Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer"
 	key_autorun, _, _ := registry.CreateKey(registry.CURRENT_USER, key_autorun_name, registry.ALL_ACCESS)
 	var key_autoplay_name = "Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\AutoplayHandlers"
 	key_autoplay, _, _ := registry.CreateKey(registry.CURRENT_USER, key_autoplay_name, registry.ALL_ACCESS)
 
-	if harden==false {
+	if harden == false {
 		events.AppendText("Restoring original settings for AutoRun and AutoPlay\n")
-		
+
 		restore_key(key_autorun, key_autorun_name, "NoDriveTypeAutoRun")
-		restore_key(key_autorun, key_autorun_name,"NoAutorun")
-		restore_key(key_autoplay, key_autoplay_name,"DisableAutoplay")
+		restore_key(key_autorun, key_autorun_name, "NoAutorun")
+		restore_key(key_autoplay, key_autoplay_name, "DisableAutoplay")
 	} else {
 		events.AppendText("Hardening by disabling AutoRun and AutoPlay\n")
-		
+
 		// save original state to be able to restore it
 		save_original_registry_DWORD(key_autorun, key_autorun_name, "NoDriveTypeAutoRun")
 		save_original_registry_DWORD(key_autorun, key_autorun_name, "NoAutorun")
 		save_original_registry_DWORD(key_autoplay, key_autoplay_name, "DisableAutoplay")
-		
+
 		key_autorun.SetDWordValue("NoDriveTypeAutoRun", 0xb5)
 		key_autorun.SetDWordValue("NoAutorun", 1)
 		key_autoplay.SetDWordValue("DisableAutoplay", 1)

--- a/autorun.go
+++ b/autorun.go
@@ -34,28 +34,11 @@ func trigger_autorun(harden bool) {
 	key_autoplay, _, _ := registry.CreateKey(registry.CURRENT_USER, key_autoplay_name, registry.ALL_ACCESS)
 
 	if harden==false {
-		events.AppendText("Restoring previous state of AutoRun and AutoPlay\n")
+		events.AppendText("Restoring original settings for AutoRun and AutoPlay\n")
 		
-		value, err := retrieve_original_registry_DWORD(key_autorun_name, "NoDriveTypeAutoRun")
-		if err == nil {
-			key_autorun.SetDWordValue("NoDriveTypeAutoRun", value)
-		} else {
-			key_autorun.DeleteValue("NoDriveTypeAutoRun")
-		}
-		
-		value, err = retrieve_original_registry_DWORD(key_autorun_name, "NoAutorun")
-		if err == nil {
-			key_autorun.SetDWordValue("NoAutorun", value)
-		} else {
-			key_autorun.DeleteValue("NoAutorun")
-		}
-		
-		value, err = retrieve_original_registry_DWORD(key_autoplay_name, "DisableAutoplay")
-		if err == nil {
-			key_autoplay.SetDWordValue("DisableAutoplay", value)
-		} else {
-			key_autorun.DeleteValue("DisableAutoplay")
-		}
+		restore_key(key_autorun, key_autorun_name, "NoDriveTypeAutoRun")
+		restore_key(key_autorun, key_autorun_name,"NoAutorun")
+		restore_key(key_autoplay, key_autoplay_name,"DisableAutoplay")
 	} else {
 		events.AppendText("Hardening by disabling AutoRun and AutoPlay\n")
 		

--- a/autorun.go
+++ b/autorun.go
@@ -28,17 +28,41 @@ import (
 - HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\AutoplayHandlers!DisableAutoplay 1
  */
 func trigger_autorun(harden bool) {
-	key_autorun, _, _ := registry.CreateKey(registry.CURRENT_USER, "Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer", registry.WRITE)
-	key_autoplay, _, _ := registry.CreateKey(registry.CURRENT_USER, "Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\AutoplayHandlers", registry.WRITE)
+	var key_autorun_name = "Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer"
+	key_autorun, _, _ := registry.CreateKey(registry.CURRENT_USER, key_autorun_name, registry.ALL_ACCESS)
+	var key_autoplay_name = "Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\AutoplayHandlers"
+	key_autoplay, _, _ := registry.CreateKey(registry.CURRENT_USER, key_autoplay_name, registry.ALL_ACCESS)
 
 	if harden==false {
-		events.AppendText("Restoring default by enabling AutoRun and AutoPlay\n")
+		events.AppendText("Restoring previous state of AutoRun and AutoPlay\n")
 		
-		key_autorun.DeleteValue("NoDriveTypeAutoRun")
-		key_autorun.DeleteValue("NoAutorun")
-		key_autoplay.DeleteValue("DisableAutoplay")
+		value, err := retrieve_original_registry_DWORD(key_autorun_name, "NoDriveTypeAutoRun")
+		if err == nil {
+			key_autorun.SetDWordValue("NoDriveTypeAutoRun", value)
+		} else {
+			key_autorun.DeleteValue("NoDriveTypeAutoRun")
+		}
+		
+		value, err = retrieve_original_registry_DWORD(key_autorun_name, "NoAutorun")
+		if err == nil {
+			key_autorun.SetDWordValue("NoAutorun", value)
+		} else {
+			key_autorun.DeleteValue("NoAutorun")
+		}
+		
+		value, err = retrieve_original_registry_DWORD(key_autoplay_name, "DisableAutoplay")
+		if err == nil {
+			key_autoplay.SetDWordValue("DisableAutoplay", value)
+		} else {
+			key_autorun.DeleteValue("DisableAutoplay")
+		}
 	} else {
 		events.AppendText("Hardening by disabling AutoRun and AutoPlay\n")
+		
+		// save original state to be able to restore it
+		save_original_registry_DWORD(key_autorun, key_autorun_name, "NoDriveTypeAutoRun")
+		save_original_registry_DWORD(key_autorun, key_autorun_name, "NoAutorun")
+		save_original_registry_DWORD(key_autoplay, key_autoplay_name, "DisableAutoplay")
 		
 		key_autorun.SetDWordValue("NoDriveTypeAutoRun", 0xb5)
 		key_autorun.SetDWordValue("NoAutorun", 1)

--- a/explorer.go
+++ b/explorer.go
@@ -37,23 +37,23 @@ import (
 // - .pif Normally, a PIF file contains information that defines how an MS-DOS-based program should run. Windows analyzes PIF files with the ShellExecute function and may run them as executable programs. Therefore, a PIF file can be used to transmit viruses or other harmful scripts.
 func trigger_fileassoc(harden bool) {
 	type Extension struct {
-		ext string
+		ext   string
 		assoc string
 	}
-	var extensions = [8]Extension {
-		{ ".hta", "htafile" },
-		{ ".js", "JSFile" },
-		{ ".JSE", "JSEFile" },
-		{ ".WSH", "WSHFile" },
-		{ ".WSF", "WSFFile" },
-		{ ".scr", "scrfile" },
-		{ ".vbs", "VBSFile" },
-		{ ".pif", "piffile" },
+	var extensions = [8]Extension{
+		{".hta", "htafile"},
+		{".js", "JSFile"},
+		{".JSE", "JSEFile"},
+		{".WSH", "WSHFile"},
+		{".WSF", "WSFFile"},
+		{".scr", "scrfile"},
+		{".vbs", "VBSFile"},
+		{".pif", "piffile"},
 	}
 
-	if harden==false {
+	if harden == false {
 		events.AppendText("Restoring default settings by enabling potentially malicious file associations\n")
-		
+
 		for _, extension := range extensions {
 			// Step 1: Reassociate system wide default
 			assocString := fmt.Sprintf("assoc %s=%s", extension.ext, extension.assoc)
@@ -62,16 +62,16 @@ func trigger_fileassoc(harden bool) {
 				events.AppendText("error occured")
 				events.AppendText(fmt.Sprintln("%s", err))
 			}
-			
+
 			// Step 2 (Reassociate user defaults) is not necessary, since this is automatically done by Windows on first usage
 		}
 	} else {
 		events.AppendText("Hardening by disabling potentially malicious file associations\n")
-		
+
 		for _, extension := range extensions {
 			regKeyString := fmt.Sprintf("SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\FileExts\\%s\\OpenWithProgids", extension.ext)
 			regKey, _ := registry.OpenKey(registry.CURRENT_USER, regKeyString, registry.ALL_ACCESS)
-			
+
 			// Step 1: Remove association (system wide default)
 			assocString := fmt.Sprintf("assoc %s=", extension.ext)
 			_, err := exec.Command("cmd.exe", "/E:ON", "/C", assocString).Output()

--- a/main.go
+++ b/main.go
@@ -17,10 +17,10 @@
 package main
 
 import (
-	"os"
 	"github.com/lxn/walk"
-	"golang.org/x/sys/windows/registry"
 	. "github.com/lxn/walk/declarative"
+	"golang.org/x/sys/windows/registry"
+	"os"
 )
 
 var window *walk.MainWindow
@@ -73,7 +73,7 @@ func restore_all() {
 	mark_status(false)
 
 	walk.MsgBox(window, "Done!", "I have restored all risky features!\nFor all changes to take effect please restart Windows.", walk.MsgBoxIconExclamation)
-	os.Exit(0)  
+	os.Exit(0)
 }
 
 func trigger_all(harden bool) {
@@ -87,7 +87,7 @@ func trigger_all(harden bool) {
 	trigger_powershell(harden)
 	trigger_uac(harden)
 	trigger_fileassoc(harden)
-	progress.SetValue(100) 
+	progress.SetValue(100)
 }
 
 func main() {
@@ -106,13 +106,13 @@ func main() {
 
 	MainWindow{
 		AssignTo: &window,
-		Title: "Harden - Security Without Borders",
-		MinSize: Size{400, 300},
-		Layout: VBox{},
+		Title:    "Harden - Security Without Borders",
+		MinSize:  Size{400, 300},
+		Layout:   VBox{},
 		Children: []Widget{
 			Label{Text: label_text},
 			PushButton{
-				Text: button_text,
+				Text:      button_text,
 				OnClicked: button_func,
 			},
 			ProgressBar{
@@ -120,7 +120,7 @@ func main() {
 			},
 			TextEdit{
 				AssignTo: &events,
-				Text: events_text,
+				Text:     events_text,
 				ReadOnly: true,
 			},
 		},

--- a/office.go
+++ b/office.go
@@ -50,13 +50,8 @@ func restore_office(pathRegEx string, value_name string) {
 		for _, office_app := range office_apps {
 			path := fmt.Sprintf(pathRegEx, office_version, office_app)
 			key, _ := registry.OpenKey(registry.CURRENT_USER, path, registry.ALL_ACCESS)
-			// retrieve saved state
-			value, err := retrieve_original_registry_DWORD(path, value_name)
-			if err == nil {
-				key.SetDWordValue(value_name, value)
-			} else {
-				key.DeleteValue(value_name)
-			}
+			// restore previous state
+			restore_key(key, path, value_name)
 			key.Close()
 		}
 	}

--- a/office.go
+++ b/office.go
@@ -45,7 +45,7 @@ func harden_office(pathRegEx string, value_name string, value uint32) {
 	}
 }
 
-func restore_office(pathRegEx string, value_name string, default_value uint32) {
+func restore_office(pathRegEx string, value_name string) {
 	for _, office_version := range office_versions {
 		for _, office_app := range office_apps {
 			path := fmt.Sprintf(pathRegEx, office_version, office_app)
@@ -55,7 +55,7 @@ func restore_office(pathRegEx string, value_name string, default_value uint32) {
 			if err == nil {
 				key.SetDWordValue(value_name, value)
 			} else {
-				key.SetDWordValue(value_name, default_value)
+				key.DeleteValue(value_name)
 			}
 			key.Close()
 		}
@@ -75,10 +75,9 @@ func trigger_ole(harden bool) {
 	var pathRegEx = "SOFTWARE\\Microsoft\\Office\\%s\\%s\\Security"
 	
 	if harden==false {
-		events.AppendText("Restoring default by enabling Office Packager Objects\n")
-		var default_value uint32 = 1
+		events.AppendText("Restoring original settings for Office Packager Objects\n")
 		
-		restore_office(pathRegEx, value_name, default_value)
+		restore_office(pathRegEx, value_name)
 	} else {
 		events.AppendText("Hardening by disabling Office Packager Objects\n")
 		var value uint32 = 2
@@ -108,9 +107,8 @@ func trigger_macro(harden bool) {
 		harden_office(pathRegEx, value_name, value)
 	} else {
 		events.AppendText("Restoring original settings for Office Macros\n")
-		var default_value uint32 = 2
 		
-		restore_office(pathRegEx, value_name, default_value)
+		restore_office(pathRegEx, value_name)
 	}
 }
 
@@ -122,7 +120,7 @@ func trigger_activex(harden bool) {
 	var value_name = "DisableAllActiveX"
 
 	if harden==false {
-		events.AppendText("Restoring default by enabling ActiveX in Office\n")
+		events.AppendText("Restoring original settings for ActiveX in Office\n")
 		// retrieve saved state
 		value, err := retrieve_original_registry_DWORD(path, value_name)
 		if err == nil {

--- a/office.go
+++ b/office.go
@@ -68,15 +68,15 @@ func restore_office(pathRegEx string, value_name string) {
 func trigger_ole(harden bool) {
 	var value_name = "PackagerPrompt"
 	var pathRegEx = "SOFTWARE\\Microsoft\\Office\\%s\\%s\\Security"
-	
-	if harden==false {
+
+	if harden == false {
 		events.AppendText("Restoring original settings for Office Packager Objects\n")
-		
+
 		restore_office(pathRegEx, value_name)
 	} else {
 		events.AppendText("Hardening by disabling Office Packager Objects\n")
 		var value uint32 = 2
-		
+
 		harden_office(pathRegEx, value_name, value)
 	}
 }
@@ -94,15 +94,15 @@ func trigger_macro(harden bool) {
 	var value uint32
 	var value_name = "VBAWarnings"
 	var pathRegEx = "SOFTWARE\\Microsoft\\Office\\%s\\%s\\Security"
-	
-	if harden==true {
+
+	if harden == true {
 		events.AppendText("Hardening by disabling Office Macros\n")
 		value = 4
-		
+
 		harden_office(pathRegEx, value_name, value)
 	} else {
 		events.AppendText("Restoring original settings for Office Macros\n")
-		
+
 		restore_office(pathRegEx, value_name)
 	}
 }
@@ -114,7 +114,7 @@ func trigger_activex(harden bool) {
 	key, _, _ := registry.CreateKey(registry.CURRENT_USER, path, registry.WRITE)
 	var value_name = "DisableAllActiveX"
 
-	if harden==false {
+	if harden == false {
 		events.AppendText("Restoring original settings for ActiveX in Office\n")
 		// retrieve saved state
 		value, err := retrieve_original_registry_DWORD(path, value_name)
@@ -132,4 +132,3 @@ func trigger_activex(harden bool) {
 	}
 	key.Close()
 }
-

--- a/powershell.go
+++ b/powershell.go
@@ -36,12 +36,12 @@ func trigger_powershell(harden bool) {
 	hardentools_key, _, _ := registry.CreateKey(registry.CURRENT_USER, harden_key_path, registry.ALL_ACCESS)
 
 	// enable
-	if harden==false {
+	if harden == false {
 		events.AppendText("Restoring original settings by enabling Powershell and cmd\n")
 
 		// set DisallowRun to old value / delete if no old value saved
 		restore_key(key_explorer, key_explorer_name, "DisallowRun")
-		
+
 		// delete values for disallowed executables (by iterating all existing values)
 		// TODO: This only works if the hardentools values are the last
 		//       ones (if values are deleted and numbers are not in

--- a/powershell.go
+++ b/powershell.go
@@ -31,27 +31,17 @@ Disables Powershell and cmd.exe
  "3"="cmd.exe"
 */
 func trigger_powershell(harden bool) {
-	key_explorer, _, _ := registry.CreateKey(registry.CURRENT_USER, "Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer", registry.ALL_ACCESS)
+	key_explorer_name := "Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer"
+	key_explorer, _, _ := registry.CreateKey(registry.CURRENT_USER, key_explorer_name, registry.ALL_ACCESS)
 	hardentools_key, _, _ := registry.CreateKey(registry.CURRENT_USER, harden_key_path, registry.ALL_ACCESS)
 
 	// enable
 	if harden==false {
-		events.AppendText("Restoring original setting by enabling Powershell and cmd\n")
+		events.AppendText("Restoring original settings by enabling Powershell and cmd\n")
 
 		// set DisallowRun to old value / delete if no old value saved
-		saved_state, _, err_sst := hardentools_key.GetIntegerValue("SavedStateDisallowRun")
-		if err_sst == nil {
-			err := key_explorer.SetDWordValue("DisallowRun", uint32(saved_state))
-			if err != nil {
-				events.AppendText("!! SetValue to enable Powershell and cmd failed.\n")
-			}
-		} else {
-			err := key_explorer.DeleteValue("DisallowRun")
-			if err != nil {
-				events.AppendText("!! DeleteValue to enable Powershell and cmd failed.\n")
-			}
-		}
-
+		restore_key(key_explorer, key_explorer_name, "DisallowRun")
+		
 		// delete values for disallowed executables (by iterating all existing values)
 		// TODO: This only works if the hardentools values are the last
 		//       ones (if values are deleted and numbers are not in
@@ -73,20 +63,11 @@ func trigger_powershell(harden bool) {
 			}
 		}
 		key_disallow.Close()
-
-		hardentools_key.DeleteValue("SavedStateDisallowRun")
 	} else {
 		events.AppendText("Hardening by disabling Powershell and cmd\n")
 
-		// handle current state (save if not default, to be able to restore former state)
-		current_state, _, err_cs := key_explorer.GetIntegerValue("DisallowRun")
-		if err_cs != nil {
-			// no need to save state
-			//events.AppendText("Error reading DisallowRun value\n")
-		} else {
-			// save state
-			hardentools_key.SetDWordValue("SavedStateDisallowRun", uint32(current_state))
-		}
+		// save original state of "DisallowRun" value to be able to restore it
+		save_original_registry_DWORD(key_explorer, key_explorer_name, "DisallowRun")
 
 		// create DisallowRun key
 		key_disallow, _, err := registry.CreateKey(registry.CURRENT_USER, "Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer\\DisallowRun", registry.ALL_ACCESS)

--- a/restore.go
+++ b/restore.go
@@ -20,6 +20,8 @@ import (
 	"golang.org/x/sys/windows/registry"
 )
 
+// TODO: Add error handling for all methods
+
 // save original registry key
 func save_original_registry_DWORD(key registry.Key, key_name string, value_name string){
 	hardentools_key, _, _ := registry.CreateKey(registry.CURRENT_USER, harden_key_path, registry.ALL_ACCESS)
@@ -43,4 +45,14 @@ func retrieve_original_registry_DWORD(key_name string, value_name string) (value
 		return uint32(value64), nil
 	}
 	return 0, err
+}
+
+// Helper method for restoring original state
+func restore_key(key registry.Key, key_name string, value_name string){
+	value, err := retrieve_original_registry_DWORD(key_name, value_name)
+	if err == nil {
+		key.SetDWordValue(value_name, value)
+	} else {
+		key.DeleteValue(value_name)
+	}
 }

--- a/restore.go
+++ b/restore.go
@@ -23,10 +23,10 @@ import (
 // TODO: Add error handling for all methods
 
 // save original registry key
-func save_original_registry_DWORD(key registry.Key, key_name string, value_name string){
+func save_original_registry_DWORD(key registry.Key, key_name string, value_name string) {
 	hardentools_key, _, _ := registry.CreateKey(registry.CURRENT_USER, harden_key_path, registry.ALL_ACCESS)
-	
-	original_value, _, err := key.GetIntegerValue(value_name);
+
+	original_value, _, err := key.GetIntegerValue(value_name)
 	if err == nil {
 		// save state
 		hardentools_key.SetDWordValue("SavedState_"+key_name+"_"+value_name, uint32(original_value))
@@ -35,11 +35,11 @@ func save_original_registry_DWORD(key registry.Key, key_name string, value_name 
 }
 
 // restore registry key from saved state
-func retrieve_original_registry_DWORD(key_name string, value_name string) (value uint32, err error){
+func retrieve_original_registry_DWORD(key_name string, value_name string) (value uint32, err error) {
 	hardentools_key, _, _ := registry.CreateKey(registry.CURRENT_USER, harden_key_path, registry.ALL_ACCESS)
-	
+
 	// retrieve saved state
-	value64, _, err := hardentools_key.GetIntegerValue("SavedState_"+key_name+"_"+value_name)
+	value64, _, err := hardentools_key.GetIntegerValue("SavedState_" + key_name + "_" + value_name)
 	hardentools_key.Close()
 	if err == nil {
 		return uint32(value64), nil
@@ -48,7 +48,7 @@ func retrieve_original_registry_DWORD(key_name string, value_name string) (value
 }
 
 // Helper method for restoring original state
-func restore_key(key registry.Key, key_name string, value_name string){
+func restore_key(key registry.Key, key_name string, value_name string) {
 	value, err := retrieve_original_registry_DWORD(key_name, value_name)
 	if err == nil {
 		key.SetDWordValue(value_name, value)

--- a/restore.go
+++ b/restore.go
@@ -1,0 +1,46 @@
+// Hardentools
+// Copyright (C) 2017  Security Without Borders
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"golang.org/x/sys/windows/registry"
+)
+
+// save original registry key
+func save_original_registry_DWORD(key registry.Key, key_name string, value_name string){
+	hardentools_key, _, _ := registry.CreateKey(registry.CURRENT_USER, harden_key_path, registry.ALL_ACCESS)
+	
+	original_value, _, err := key.GetIntegerValue(value_name);
+	if err == nil {
+		// save state
+		hardentools_key.SetDWordValue("SavedState_"+key_name+"_"+value_name, uint32(original_value))
+	}
+	hardentools_key.Close()
+}
+
+// restore registry key from saved state
+func retrieve_original_registry_DWORD(key_name string, value_name string) (value uint32, err error){
+	hardentools_key, _, _ := registry.CreateKey(registry.CURRENT_USER, harden_key_path, registry.ALL_ACCESS)
+	
+	// retrieve saved state
+	value64, _, err := hardentools_key.GetIntegerValue("SavedState_"+key_name+"_"+value_name)
+	hardentools_key.Close()
+	if err == nil {
+		return uint32(value64), nil
+	}
+	return 0, err
+}

--- a/uac.go
+++ b/uac.go
@@ -21,23 +21,23 @@ import (
 )
 
 func trigger_uac(harden bool) {
-	key, _ := registry.OpenKey(registry.LOCAL_MACHINE, "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System", registry.WRITE)
-
+	key_name := "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System"
+	key, _ := registry.OpenKey(registry.LOCAL_MACHINE, key_name, registry.ALL_ACCESS)
+	value_name := "ConsentPromptBehaviorAdmin"
+	
 	if harden==false {
-		events.AppendText("Restoring default by restoring UAC to default settings\n")
-		
-		err := key.SetDWordValue("ConsentPromptBehaviorAdmin", 5)
-		if err != nil {
-			events.AppendText("!! SetDWordValue on UAC failed.\n")
-		}
+		events.AppendText("Restoring original UAC settings\n")
+		restore_key(key, key_name, value_name)
 	} else {
 		events.AppendText("Hardening by setting UAC to prompt for consent on secure desktops\n")
+		var value uint32 = 2
 		
-		err := key.SetDWordValue("ConsentPromptBehaviorAdmin", 2)
-		if err != nil {
-			events.AppendText("!! SetDWordValue on UAC failed.\n")
-		}
+		// save original state to be able to restore it
+		save_original_registry_DWORD(key, key_name, value_name)
+		
+		// harden
+		key.SetDWordValue(value_name, value)
 	}
-
+	
 	key.Close()
 }

--- a/uac.go
+++ b/uac.go
@@ -24,20 +24,20 @@ func trigger_uac(harden bool) {
 	key_name := "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System"
 	key, _ := registry.OpenKey(registry.LOCAL_MACHINE, key_name, registry.ALL_ACCESS)
 	value_name := "ConsentPromptBehaviorAdmin"
-	
-	if harden==false {
+
+	if harden == false {
 		events.AppendText("Restoring original UAC settings\n")
 		restore_key(key, key_name, value_name)
 	} else {
 		events.AppendText("Hardening by setting UAC to prompt for consent on secure desktops\n")
 		var value uint32 = 2
-		
+
 		// save original state to be able to restore it
 		save_original_registry_DWORD(key, key_name, value_name)
-		
+
 		// harden
 		key.SetDWordValue(value_name, value)
 	}
-	
+
 	key.Close()
 }

--- a/wsh.go
+++ b/wsh.go
@@ -25,16 +25,16 @@ func trigger_wsh(harden bool) {
 	key, _, _ := registry.CreateKey(registry.CURRENT_USER, key_name, registry.ALL_ACCESS)
 	value_name := "Enabled"
 
-	if harden==false {
+	if harden == false {
 		events.AppendText("Restoring original settings for Windows Script Host\n")
 		restore_key(key, key_name, value_name)
 	} else {
 		events.AppendText("Hardening by disabling Windows Script Host\n")
 		var value uint32 = 0
-		
+
 		// save original state to be able to restore it
 		save_original_registry_DWORD(key, key_name, value_name)
-		
+
 		// harden
 		key.SetDWordValue(value_name, value)
 	}

--- a/wsh.go
+++ b/wsh.go
@@ -21,14 +21,22 @@ import (
 )
 
 func trigger_wsh(harden bool) {
-	key, _, _ := registry.CreateKey(registry.CURRENT_USER, "SOFTWARE\\Microsoft\\Windows Script Host\\Settings", registry.WRITE)
+	key_name := "SOFTWARE\\Microsoft\\Windows Script Host\\Settings"
+	key, _, _ := registry.CreateKey(registry.CURRENT_USER, key_name, registry.ALL_ACCESS)
+	value_name := "Enabled"
 
 	if harden==false {
-		events.AppendText("Restoring default by enabling Windows Script Host\n")
-		key.DeleteValue("Enabled")
+		events.AppendText("Restoring original settings for Windows Script Host\n")
+		restore_key(key, key_name, value_name)
 	} else {
 		events.AppendText("Hardening by disabling Windows Script Host\n")
-		key.SetDWordValue("Enabled", 0)
+		var value uint32 = 0
+		
+		// save original state to be able to restore it
+		save_original_registry_DWORD(key, key_name, value_name)
+		
+		// harden
+		key.SetDWordValue(value_name, value)
 	}
 
 	key.Close()


### PR DESCRIPTION
This should fix #20, by saving existing registry keys in the registry (when doing "Harden") and restoring the original values (when doing "Restore) or deleting the values if originally the value didn't exist.

This needs further testing, especially if the harding functionality is still in place (only did some rudimentary testing). Only tested on Win 10 also.

Testing should best be done on a fresh system. If you have used Hardentools before, you should first do a restore with the old version and only then use the new version. Otherwise the restore will delete all relevant registry values.
