### PR TITLE
Adds logging, improves error handling and code cleanups

### DIFF
--- a/adobe.go
+++ b/adobe.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"fmt"
+
 	"golang.org/x/sys/windows/registry"
 )
 
@@ -136,21 +137,34 @@ func (adobeRegEx *AdobeRegistryRegExSingleDWORD) Harden(harden bool) error {
 		// Harden.
 		for _, adobeVersion := range adobeRegEx.AdobeVersions {
 			path := fmt.Sprintf(adobeRegEx.PathRegEx, adobeVersion)
-			key, _, _ := registry.CreateKey(adobeRegEx.RootKey, path, registry.ALL_ACCESS)
+			err := HardenDwordValue(adobeRegEx.RootKey, path, adobeRegEx.ValueName, adobeRegEx.HardenedValue)
+			if err != nil {
+				return err
+			}
+			/*
+				key, _, _ := registry.CreateKey(adobeRegEx.RootKey, path, registry.ALL_ACCESS)
+				defer key.Close()
 
-			saveOriginalRegistryDWORD(key, path, adobeRegEx.ValueName)
+				err := saveOriginalRegistryDWORD(adobeRegEx.RootKey, path, adobeRegEx.ValueName)
+				if err != nil {
+					return err
+				}
 
-			key.SetDWordValue(adobeRegEx.ValueName, adobeRegEx.HardenedValue)
-			key.Close()
+				err = key.SetDWordValue(adobeRegEx.ValueName, adobeRegEx.HardenedValue)
+				if err != nil {
+					log.Println("Error when hardening registry value " + adobeRegEx.ValueName + " = " + strconv.FormatUint(uint64(adobeRegEx.HardenedValue), 16))
+					return err
+				}*/
 		}
 	} else {
 		// Restore.
 		for _, adobeVersion := range adobeRegEx.AdobeVersions {
 			path := fmt.Sprintf(adobeRegEx.PathRegEx, adobeVersion)
-			key, _ := registry.OpenKey(adobeRegEx.RootKey, path, registry.ALL_ACCESS)
 
-			restoreKey(key, path, adobeRegEx.ValueName)
-			key.Close()
+			err := restoreKey(adobeRegEx.RootKey, path, adobeRegEx.ValueName)
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/build.sh
+++ b/build.sh
@@ -9,9 +9,9 @@ go get gopkg.in/Knetic/govaluate.v3
 # check go version
 GO_VERSION="$(go version)"
 GO_VERSION="$(echo $GO_VERSION | awk '{print $3}')"
-if [[ $GO_VERSION == "go1.9"* ]]; then
+if [[ $GO_VERSION == "go1.9"* ]] || [[ $GO_VERSION == "go1.8"* ]]; then
 	$GOPATH/bin/rsrc -manifest harden.manifest -ico harden.ico -o rsrc.syso
 	GOOS=windows GOARCH=386 CC=i686-w64-mingw32-gcc CGO_ENABLED=1 go build --ldflags '-s -w -extldflags "-static" -H windowsgui' -o hardentools.exe
 else
-	echo "Error: Build currently only works with go1.9.X"
+	echo "Error: Build currently only works with go 1.8.x or go1.9.X"
 fi

--- a/explorer.go
+++ b/explorer.go
@@ -18,8 +18,9 @@ package main
 
 import (
 	"fmt"
-	"golang.org/x/sys/windows/registry"
 	"os/exec"
+
+	"golang.org/x/sys/windows/registry"
 )
 
 // What better not to disable:
@@ -92,7 +93,8 @@ func (explAssoc ExplorerAssociations) Harden(harden bool) error {
 			regKeyString := fmt.Sprintf("SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\FileExts\\%s\\OpenWithProgids", extension.ext)
 			regKey, err := registry.OpenKey(registry.CURRENT_USER, regKeyString, registry.ALL_ACCESS)
 			if err != nil {
-				fmt.Println("Info: Open ", regKeyString, "failed")
+				//fmt.Println("Info: Open ", regKeyString, "failed")
+
 				// do not return an error, because it seems to be quite common that this does not exist for different extensions;
 				// just remember this for later
 				openWithProgidsDoesNotExist = true
@@ -103,7 +105,7 @@ func (explAssoc ExplorerAssociations) Harden(harden bool) error {
 			assocString := fmt.Sprintf("assoc %s=", extension.ext)
 			_, err2 := exec.Command("cmd.exe", "/E:ON", "/C", assocString).Output()
 			if err2 != nil {
-				fmt.Println("Executing ", assocString, " failed")
+				//fmt.Println("Executing ", assocString, " failed")
 				return err2
 			}
 
@@ -113,7 +115,7 @@ func (explAssoc ExplorerAssociations) Harden(harden bool) error {
 				for _, valueName := range valueNames {
 					err3 := regKey.DeleteValue(valueName)
 					if err3 != nil {
-						fmt.Println("Removing user association ", valueName, " failed")
+						//fmt.Println("Removing user association ", valueName, " failed")
 						return err3
 					}
 				}
@@ -138,9 +140,9 @@ func (explAssoc ExplorerAssociations) IsHardened() (isHardened bool) {
 
 		// Step 1: Check association (system wide default)
 		assocString := fmt.Sprintf("assoc %s", extension.ext)
-		out, err := exec.Command("cmd.exe", "/E:ON", "/C", assocString).Output()
-		fmt.Print(assocString, " output = ", string(out[:]))
-		fmt.Println("err = ", err)
+		_, err := exec.Command("cmd.exe", "/E:ON", "/C", assocString).Output()
+		//fmt.Print(assocString, " output = ", string(out[:]))
+		//fmt.Println("err = ", err)
 		if err != nil {
 			hardened = true
 		}

--- a/hardenInterface.go
+++ b/hardenInterface.go
@@ -33,6 +33,7 @@ type MultiHardenInterfaces struct {
 	description      string
 }
 
+// the Harden() method hardens (if harden == true) or restores (if harden == false) MultiHardenInterfaces
 func (mhInterfaces *MultiHardenInterfaces) Harden(harden bool) error {
 	for _, mhInterface := range mhInterfaces.hardenInterfaces {
 		err := mhInterface.Harden(harden)
@@ -43,6 +44,7 @@ func (mhInterfaces *MultiHardenInterfaces) Harden(harden bool) error {
 	return nil
 }
 
+// the IsHardened() method verifies if all MultiHardenInterfaces members are hardenend
 func (mhInterfaces *MultiHardenInterfaces) IsHardened() bool {
 	var hardened = true
 

--- a/hardenInterface.go
+++ b/hardenInterface.go
@@ -66,12 +66,3 @@ func (mhInterfaces *MultiHardenInterfaces) LongName() string {
 func (mhInterfaces *MultiHardenInterfaces) Description() string {
 	return mhInterfaces.description
 }
-
-// error handling
-type HardenError struct {
-	err string
-}
-
-func (e HardenError) Error() string {
-	return e.err
-}

--- a/main.go
+++ b/main.go
@@ -183,7 +183,13 @@ func main() {
 	var status = checkStatus()
 
 	// Init logging
-	InitLogging(os.Stdout, os.Stdout) // use this for developing/testing
+	var logpath = "hardentools.log"
+	var logfile, err = os.Create(logpath)
+	if err != nil {
+		// do nothing for now
+		//panic(err)
+	}
+	InitLogging(logfile, logfile) // use this for developing/testing
 	//InitLogging(ioutil.Discard, os.Stdout)  // use this for production use
 
 	// build up expert settings checkboxes and map

--- a/main.go
+++ b/main.go
@@ -163,7 +163,7 @@ func triggerAll(harden bool) {
 
 			err := hardenSubject.Harden(harden)
 			if err != nil {
-				events.AppendText(fmt.Sprintf("!! Operation for %s FAILED !!\n", hardenSubject.Name()))
+				events.AppendText(fmt.Sprintf("\n!! %s %s FAILED !!\n", outputString, hardenSubject.Name()))
 				Info.Printf("Error for operation %s: %s", hardenSubject.Name(), err.Error())
 			} else {
 				Info.Printf("%s %s has been successful", outputString, hardenSubject.Name())
@@ -194,7 +194,7 @@ func showStatus() {
 }
 
 func main() {
-	var labelText, buttonText, eventsText string
+	var labelText, buttonText, eventsText, expertSettingsText string
 	var buttonFunc func()
 	var status = checkStatus()
 
@@ -206,7 +206,7 @@ func main() {
 		//panic(err)
 	}
 	InitLogging(logfile, logfile) // use this for developing/testing
-	//InitLogging(ioutil.Discard, os.Stdout)  // use this for production use
+	//InitLogging(ioutil.Discard, logfile)  // use this for production use
 
 	// build up expert settings checkboxes and map
 	expertConfig = make(map[string]bool)
@@ -220,11 +220,13 @@ func main() {
 		if status == false {
 			// all checkboxes checked by default, disabled only if subject is already hardened
 			expertConfig[hardenSubject.Name()] = !subjectIsHardened
+
 			// only enable, if not already hardenend
 			enableField = !subjectIsHardened
 		} else {
 			// restore: only checkboxes checked which are hardenend
 			expertConfig[hardenSubject.Name()] = subjectIsHardened
+
 			// disable all, since the user must restore all settings because otherwise
 			// consecutive execution of hardentools might fail (e.g. starting powershell
 			// or cmd commands) or might be ineffectiv (settings are already hardened) or
@@ -247,10 +249,12 @@ func main() {
 		buttonText = "Harden!"
 		buttonFunc = hardenAll
 		labelText = "Ready to harden some features of your system?"
+		expertSettingsText = "Expert Settings - change only if you now what you are doing! Disabled settings are already hardened."
 	} else {
 		buttonText = "Restore..."
 		buttonFunc = restoreAll
 		labelText = "We have already hardened some risky features, do you want to restore them?"
+		expertSettingsText = "The following hardened features are going to be restored:"
 	}
 
 	MainWindow{
@@ -279,7 +283,7 @@ func main() {
 			},
 			HSpacer{},
 			HSpacer{},
-			Label{Text: "Expert Settings - change only if you now what you are doing! Disabled settings are already hardened."},
+			Label{Text: expertSettingsText},
 			Composite{
 				Layout:   Grid{Columns: 3},
 				Border:   true,

--- a/main.go
+++ b/main.go
@@ -105,16 +105,29 @@ func checkStatus() bool {
 }
 
 func markStatus(hardened bool) {
-	key, _, err := registry.CreateKey(registry.CURRENT_USER, hardentoolsKeyPath, registry.WRITE)
-	if err != nil {
-		panic(err)
-	}
-	defer key.Close()
 
 	if hardened {
-		key.SetDWordValue("Harden", 1)
+		key, _, err := registry.CreateKey(registry.CURRENT_USER, hardentoolsKeyPath, registry.ALL_ACCESS)
+		if err != nil {
+			Info.Println(err.Error())
+			panic(err)
+		}
+		defer key.Close()
+
+		// set value that states that we have hardened the system
+		err = key.SetDWordValue("Harden", 1)
+		if err != nil {
+			Info.Println(err.Error())
+			walk.MsgBox(window, "ERROR", "Could not set hardentools registry keys - restore will not work!", walk.MsgBoxIconExclamation)
+			panic(err)
+		}
 	} else {
-		key.SetDWordValue("Harden", 0)
+		// on restore delete all hardentools registry keys afterwards
+		err := registry.DeleteKey(registry.CURRENT_USER, hardentoolsKeyPath)
+		if err != nil {
+			Info.Println(err.Error())
+			events.AppendText("Could not remove hardentools registry keys - nothing to worry about.")
+		}
 	}
 }
 
@@ -135,10 +148,13 @@ func restoreAll() {
 }
 
 func triggerAll(harden bool) {
+	var outputString string
 	if harden {
 		events.AppendText("Now we are hardening ")
+		outputString = "Hardening"
 	} else {
 		events.AppendText("Now we are restoring ")
+		outputString = "Restoring"
 	}
 
 	for _, hardenSubject := range allHardenSubjects {
@@ -150,7 +166,7 @@ func triggerAll(harden bool) {
 				events.AppendText(fmt.Sprintf("!! Operation for %s FAILED !!\n", hardenSubject.Name()))
 				Info.Printf("Error for operation %s: %s", hardenSubject.Name(), err.Error())
 			} else {
-				Info.Printf("Hardening %s has been successful", hardenSubject.Name())
+				Info.Printf("%s %s has been successful", outputString, hardenSubject.Name())
 			}
 		}
 	}
@@ -199,11 +215,22 @@ func main() {
 
 	for i, hardenSubject := range allHardenSubjects {
 		var subjectIsHardened = hardenSubject.IsHardened()
+		var enableField bool
 
 		if status == false {
-			expertConfig[hardenSubject.Name()] = true // all checkboxes enabled by default in case of hardening
+			// all checkboxes checked by default, disabled only if subject is already hardened
+			expertConfig[hardenSubject.Name()] = !subjectIsHardened
+			// only enable, if not already hardenend
+			enableField = !subjectIsHardened
 		} else {
-			expertConfig[hardenSubject.Name()] = subjectIsHardened // restore: only checkboxes enabled which are hardenend
+			// restore: only checkboxes checked which are hardenend
+			expertConfig[hardenSubject.Name()] = subjectIsHardened
+			// disable all, since the user must restore all settings because otherwise
+			// consecutive execution of hardentools might fail (e.g. starting powershell
+			// or cmd commands) or might be ineffectiv (settings are already hardened) or
+			// hardened settings might get saved as "before" settings, so user
+			// can't revert to the state "before"
+			enableField = false
 		}
 
 		expertCompWidgetArray[i] = CheckBox{
@@ -212,7 +239,7 @@ func main() {
 			Text:             hardenSubject.LongName(),
 			Checked:          expertConfig[hardenSubject.Name()],
 			OnCheckedChanged: walk.EventHandler(checkBoxEventGenerator(i, hardenSubject.Name())),
-			Enabled:          !(status && !subjectIsHardened) || !status,
+			Enabled:          enableField,
 		}
 	}
 
@@ -252,7 +279,7 @@ func main() {
 			},
 			HSpacer{},
 			HSpacer{},
-			Label{Text: "Expert Settings - change only if you now what you are doing!"},
+			Label{Text: "Expert Settings - change only if you now what you are doing! Disabled settings are already hardened."},
 			Composite{
 				Layout:   Grid{Columns: 3},
 				Border:   true,

--- a/powershell.go
+++ b/powershell.go
@@ -17,8 +17,10 @@
 package main
 
 import (
-	"golang.org/x/sys/windows/registry"
+	"errors"
 	"strconv"
+
+	"golang.org/x/sys/windows/registry"
 )
 
 type PowerShellDisallowRunMembers struct {
@@ -67,7 +69,7 @@ func (pwShell PowerShellDisallowRunMembers) Harden(harden bool) error {
 
 		keyDisallow, err := registry.OpenKey(registry.CURRENT_USER, "Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer\\DisallowRun", registry.ALL_ACCESS)
 		if err != nil {
-			return HardenError{"!! OpenKey to enable Powershell and cmd failed.\n"}
+			return errors.New("!! OpenKey to enable Powershell and cmd failed.\n")
 		}
 		defer keyDisallow.Close()
 
@@ -86,7 +88,7 @@ func (pwShell PowerShellDisallowRunMembers) Harden(harden bool) error {
 		// Create or Open DisallowRun key.
 		keyDisallow, _, err := registry.CreateKey(registry.CURRENT_USER, "Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer\\DisallowRun", registry.ALL_ACCESS)
 		if err != nil {
-			return HardenError{"!! CreateKey to disable powershell failed.\n"}
+			return errors.New("!! CreateKey to disable powershell failed.\n")
 		}
 		defer keyDisallow.Close()
 

--- a/registryUtils.go
+++ b/registryUtils.go
@@ -17,12 +17,16 @@
 package main
 
 import (
+	"errors"
 	"fmt"
+	"log"
+	"strconv"
+
 	"golang.org/x/sys/windows/registry"
 )
 
-// data type for a single DWORD value that suffices for hardening
-// a distinct setting
+// data type for a single registry DWORD value that suffices for hardening
+// a distinct setting or as part of an RegistryMultiValue
 type RegistrySingleValueDWORD struct {
 	RootKey       registry.Key
 	Path          string
@@ -33,6 +37,8 @@ type RegistrySingleValueDWORD struct {
 	description   string
 }
 
+// data type for multiple SingleValueDWORDs
+// use if a single hardening needs multiple RegistrySingleValueDWORD to be modified
 type RegistryMultiValue struct {
 	ArraySingleDWORD []*RegistrySingleValueDWORD
 	shortName        string
@@ -40,32 +46,35 @@ type RegistryMultiValue struct {
 	description      string
 }
 
-// harden RegistrySingleValueDWORD helper method
+// harden function for RegistrySingleValueDWORD struct
 func (regValue *RegistrySingleValueDWORD) Harden(harden bool) error {
-	key, _, err := registry.CreateKey(regValue.RootKey, regValue.Path, registry.WRITE)
-	defer key.Close()
-
+	/*key, _, err := registry.CreateKey(regValue.RootKey, regValue.Path, registry.WRITE)
 	if err != nil {
-		return HardenError{fmt.Sprintf("Couldn't create / open registry key for write access: %s \\ %s", regValue.RootKey, regValue.Path)}
+		return errors.New(fmt.Sprintf("Couldn't create / open registry key for write access: %s \\ %s", regValue.RootKey, regValue.Path))
 	}
+	defer key.Close()*/
 
 	if harden == false {
 		// Restore.
-		restoreKey(key, regValue.Path, regValue.ValueName)
+		return restoreKey(regValue.RootKey, regValue.Path, regValue.ValueName)
 	} else {
-		// Save current state.
-		saveOriginalRegistryDWORD(key, regValue.Path, regValue.ValueName)
+		return HardenDwordValue(regValue.RootKey, regValue.Path, regValue.ValueName, regValue.HardenedValue)
+		/*// Save current state.
+		err = saveOriginalRegistryDWORD(regValue.RootKey, regValue.Path, regValue.ValueName)
+		if err != nil {
+			return err
+		}
 		// Harden.
 		err = key.SetDWordValue(regValue.ValueName, regValue.HardenedValue)
 		if err != nil {
-			return HardenError{fmt.Sprintf("Couldn't set registry value: %s \\ %s \\ %s", regValue.RootKey, regValue.Path, regValue.ValueName)}
-		}
+			return errors.New(fmt.Sprintf("Couldn't set registry value: %s \\ %s \\ %s", regValue.RootKey, regValue.Path, regValue.ValueName))
+		}*/
 	}
 
 	return nil
 }
 
-// verify if RegistrySingleValueDWORD is already hardened (helper method)
+// verify if harden object of type RegistrySingleValueDWORD is already hardened
 func (regValue *RegistrySingleValueDWORD) IsHardened() bool {
 	key, err := registry.OpenKey(regValue.RootKey, regValue.Path, registry.READ)
 
@@ -92,16 +101,19 @@ func (regValue *RegistrySingleValueDWORD) Description() string {
 	return regValue.description
 }
 
+// harden function for RegistryMultiValue struct
 func (regMultiValue RegistryMultiValue) Harden(harden bool) error {
 	for _, singleDWORD := range regMultiValue.ArraySingleDWORD {
 		err := singleDWORD.Harden(harden)
 		if err != nil {
+			log.Fatal("Could not harden " + singleDWORD.Name() + " due to error: " + err.Error())
 			return err
 		}
 	}
 	return nil
 }
 
+// verify if harden object of type RegistryMultiValue is already hardened
 func (regMultiValue *RegistryMultiValue) IsHardened() (isHardened bool) {
 	var hardened = true
 
@@ -128,39 +140,140 @@ func (regMultiValue *RegistryMultiValue) Description() string {
 
 ////
 // save and restore methods
-//
-// TODO: Add error handling for all methods.
-////
 
-// Save original registry key.
-func saveOriginalRegistryDWORD(key registry.Key, keyName string, valueName string) {
-	hardentoolsKey, _, _ := registry.CreateKey(registry.CURRENT_USER, hardentoolsKeyPath, registry.ALL_ACCESS)
-
-	originalValue, _, err := key.GetIntegerValue(valueName)
-	if err == nil {
-		hardentoolsKey.SetDWordValue("SavedState_"+keyName+"_"+valueName, uint32(originalValue)) // TODO: add RootKey here (LOCAL_MACHINE vs. LOCAL_USER) - needed for future improvements
+// helper method for saving original registry key.
+func saveOriginalRegistryDWORD(rootKey registry.Key, keyName string, valueName string) error {
+	// open hardentools root key
+	hardentoolsKey, _, err := registry.CreateKey(registry.CURRENT_USER, hardentoolsKeyPath, registry.ALL_ACCESS)
+	if err != nil {
+		return err
 	}
-	hardentoolsKey.Close()
+	defer hardentoolsKey.Close()
+
+	// get value of registry key to save
+	keyToSave, err := registry.OpenKey(rootKey, keyName, registry.READ)
+	if err != nil {
+		log.Println("Could not open registry key to save due to error: " + err.Error())
+		return err
+	}
+	defer keyToSave.Close()
+
+	// now finally get value to save
+	originalValue, _, err := keyToSave.GetIntegerValue(valueName)
+	if err != nil {
+		log.Println("Could not retrieve value of registry key to save (" + keyName + ", " + valueName + ") due to error: " + err.Error())
+		return nil // nothing to save (no error, normal behaviour if registry key was not set)
+	} else {
+		// get name of root ke (e.g. CURRENT_USER)
+		rootKeyName, err := getRootKeyName(rootKey)
+		if err != nil {
+			return err
+		}
+
+		// save value
+		log.Println("Saving value for: " + "SavedState_" + rootKeyName + "\\" + keyName + "_" + valueName)
+		err = hardentoolsKey.SetDWordValue("SavedState_"+rootKeyName+"\\"+keyName+"_"+valueName, uint32(originalValue))
+		if err != nil {
+			log.Fatal("Could not save state")
+		}
+		return err
+	}
 }
 
-// Restore registry key from saved state.
-func retrieveOriginalRegistryDWORD(keyName string, valueName string) (value uint32, err error) {
-	hardentoolsKey, _, _ := registry.CreateKey(registry.CURRENT_USER, hardentoolsKeyPath, registry.ALL_ACCESS)
+// helper method for restoring registry key from saved state.
+func retrieveOriginalRegistryDWORD(rootKey registry.Key, keyName string, valueName string) (value uint32, err error) {
+	// open hardentools root key
+	hardentoolsKey, _, err := registry.CreateKey(registry.CURRENT_USER, hardentoolsKeyPath, registry.ALL_ACCESS)
+	if err != nil {
+		return 0, err
+	}
+	defer hardentoolsKey.Close()
 
-	value64, _, err := hardentoolsKey.GetIntegerValue("SavedState_" + keyName + "_" + valueName) // TODO: evaluate RootKey here (LOCAL_MACHINE vs. LOCAL_USER) - needed for future improvements
-	hardentoolsKey.Close()
-	if err == nil {
+	// get rootKeyName
+	rootKeyName, err := getRootKeyName(rootKey)
+	if err != nil {
+		log.Println("Could not get rootKeyName")
+		return 0, nil
+	}
+
+	// get saved state
+	value64, _, err := hardentoolsKey.GetIntegerValue("SavedState_" + rootKeyName + "\\" + keyName + "_" + valueName)
+	if err != nil {
+		//log.Println("Could not get saved state for SavedState_" + rootKeyName + "\\" + keyName + "_" + valueName)
+		return 0, err
+	} else {
 		return uint32(value64), nil
 	}
-	return 0, err
 }
 
-// Helper method for restoring original state.
-func restoreKey(key registry.Key, keyName string, valueName string) {
-	value, err := retrieveOriginalRegistryDWORD(keyName, valueName)
-	if err == nil {
-		key.SetDWordValue(valueName, value)
-	} else {
-		key.DeleteValue(valueName)
+// Helper method for restoring original state of a DWORD registry key.
+func restoreKey(rootKey registry.Key, keyName string, valueName string) (err error) {
+	// open key to be restored
+	key, err := registry.OpenKey(rootKey, keyName, registry.ALL_ACCESS)
+	if err != nil {
+		log.Println("Could not open registry key " + keyName + " due to error: " + err.Error())
+		return err
 	}
+	defer key.Close()
+
+	// get original state value
+	value, err := retrieveOriginalRegistryDWORD(rootKey, keyName, valueName)
+	if err == nil {
+		log.Println("Restoring registry value " + keyName + "\\" + valueName + " to saved state " + strconv.FormatUint(uint64(value), 16))
+		err = key.SetDWordValue(valueName, value)
+	} else {
+		log.Println("Could not get saved value, therefore deleting the registry value " + valueName)
+		err = key.DeleteValue(valueName)
+	}
+	return err
+}
+
+// get root key name (LOCAL_MACHINE vs. LOCAL_USER)
+func getRootKeyName(rootKey registry.Key) (rootKeyName string, err error) {
+	// this is kind of a hack, since registry.Key doesn't allow to get the
+	// name of the key itself
+
+	switch rootKey {
+	case registry.CLASSES_ROOT:
+		rootKeyName = "CLASSES_ROOT"
+	case registry.CURRENT_USER:
+		rootKeyName = "CURRENT_USER"
+	case registry.LOCAL_MACHINE:
+		rootKeyName = "LOCAL_MACHINE"
+	case registry.USERS:
+		rootKeyName = "USERS"
+	case registry.CURRENT_CONFIG:
+		rootKeyName = "CURRENT_CONFIG"
+	case registry.PERFORMANCE_DATA:
+		rootKeyName = "PERFORMANCE_DATA"
+	default:
+		// invalid rootKey?
+		log.Fatal("Invalid rootKey provided to save registry function")
+		err = errors.New("Invalid rootKey provided to save registry function")
+	}
+
+	return
+}
+
+// harden Dword value including saving the original state
+func HardenDwordValue(rootKey registry.Key, path string, valueName string, hardenedValue uint32) error {
+	rootKeyName, _ := getRootKeyName(rootKey)
+	key, _, err := registry.CreateKey(rootKey, path, registry.WRITE)
+	if err != nil {
+		return errors.New(fmt.Sprintf("Couldn't create / open registry key for write access: %s\\%s", rootKeyName, path))
+	}
+	defer key.Close()
+
+	// Save current state.
+	err = saveOriginalRegistryDWORD(rootKey, path, valueName)
+	if err != nil {
+		return err
+	}
+	// Harden.
+	err = key.SetDWordValue(valueName, hardenedValue)
+	if err != nil {
+		return errors.New(fmt.Sprintf("Couldn't set registry value: %s \\ %s \\ %s", rootKeyName, path, valueName))
+	}
+
+	return nil
 }

--- a/testplan.md
+++ b/testplan.md
@@ -56,7 +56,7 @@ Open every one of the following executables from explorer or Windows Start Menu:
 Executables starts
 
 **Expected result after hardening:**
-Nothing happens (windows doesn't react on mouse click)
+Nothing happens (windows doesn't react on mouse click) or displays error message
 
 
 ### Disable file extensions mainly used for malicious purposes
@@ -64,7 +64,7 @@ Nothing happens (windows doesn't react on mouse click)
 Disables the ".hta", ".js", ".JSE", ".WSH", ".WSF", ".scf", ".scr", ".vbs", ".vbe" and ".pif" file extensions for the current user (and for system wide defaults, which is only relevant for newly created users).
 
 #### Test:
-Create a file for every extension mentioned above (with the extension, empty text file is sufficient)
+Create a file for every extension mentioned above (empty text file is sufficient)
 
 **Expected result before hardening:**
 The file is shown in explorer with the appropriate icon for its extension. Upon starting the file, it is tried to open the file (corresponding error message is shown if it is not of the appropriate file type).
@@ -104,3 +104,6 @@ The file is shown in explorer with only the empty icon for unknown file types. U
 
 - **Switch on Enhanced Security** (enabled by default in current versions)
 
+## Test Restore
+
+TODO: also test partial harden and restore (and that multiple times)

--- a/windowsASR.go
+++ b/windowsASR.go
@@ -63,6 +63,7 @@ var WindowsASR = &WindowsASRStruct{
 }
 
 //// HardenInterface methods
+
 func (asr WindowsASRStruct) Harden(harden bool) error {
 	if harden {
 		// harden (but only if we have at least Windows 10 - 1709)
@@ -94,6 +95,32 @@ func (asr WindowsASRStruct) Harden(harden bool) error {
 	return nil
 }
 
+/* Unmodifed State in Windows 10 / 1709:
+	   PS> Get-MpPreference
+	    AttackSurfaceReductionOnlyExclusions          :
+	    AttackSurfaceReductionRules_Actions           :
+	    AttackSurfaceReductionRules_Ids               :
+
+      Modified State:
+	    PS > $prefs = Get-MpPreference
+		PS > $prefs.AttackSurfaceReductionOnlyExclusions
+		PS > $prefs.AttackSurfaceReductionRules_Actions
+			1
+			1
+			1
+			1
+			1
+			1
+			1
+		PS > $prefs.AttackSurfaceReductionRules_Ids
+			3B576869-A4EC-4529-8536-B80A7769E899
+			5BEB7EFE-FD9A-4556-801D-275E5FFC04CC
+			75668C1F-73B5-4CF0-BB93-3ECF5CB7CC84
+			92E97FA1-2EDF-4476-BDD6-9DD0B4DDDC7B
+			BE9BA2D9-53EA-4CDC-84E5-9B1EEEE46550
+			D3E037E1-3EB8-44C8-A917-57927947596D
+			D4F940AB-401B-4EFC-AADC-AD5F3C50688A
+*/
 func (asr WindowsASRStruct) IsHardened() bool {
 	var hardened = false
 
@@ -115,12 +142,12 @@ func (asr WindowsASRStruct) IsHardened() bool {
 		currentRuleIDs := strings.Split(ruleIDsOut, "\r\n")
 		currentRuleActions := strings.Split(ruleActionsOut, "\r\n")
 
-		// just some debug
-		/*for i, ruleIDdebug := range currentRuleIDs {
+		// just some debug output
+		for i, ruleIDdebug := range currentRuleIDs {
 			if len(ruleIDdebug) > 0 {
-				fmt.Printf("ruleID %d = %s with action = %s\n", i, ruleIDdebug, currentRuleActions[i])
+				Trace.Printf("ruleID %d = %s with action = %s\n", i, ruleIDdebug, currentRuleActions[i])
 			}
-		}*/
+		}
 
 		// compare to hardened state
 		for i, ruleIdHardened := range ruleIdArray {
@@ -147,34 +174,6 @@ func (asr WindowsASRStruct) IsHardened() bool {
 		}
 
 		return true // seems all relevant hardening is in place
-
-		/* Unmodifed State in Windows 10 / 1709:
-			   PS> Get-MpPreference
-			    AttackSurfaceReductionOnlyExclusions          :
-			    AttackSurfaceReductionRules_Actions           :
-			    AttackSurfaceReductionRules_Ids               :
-
-		      Modified State:
-			    PS > $prefs = Get-MpPreference
-				PS > $prefs.AttackSurfaceReductionOnlyExclusions
-				PS > $prefs.AttackSurfaceReductionRules_Actions
-					1
-					1
-					1
-					1
-					1
-					1
-					1
-				PS > $prefs.AttackSurfaceReductionRules_Ids
-					3B576869-A4EC-4529-8536-B80A7769E899
-					5BEB7EFE-FD9A-4556-801D-275E5FFC04CC
-					75668C1F-73B5-4CF0-BB93-3ECF5CB7CC84
-					92E97FA1-2EDF-4476-BDD6-9DD0B4DDDC7B
-					BE9BA2D9-53EA-4CDC-84E5-9B1EEEE46550
-					D3E037E1-3EB8-44C8-A917-57927947596D
-					D4F940AB-401B-4EFC-AADC-AD5F3C50688A
-		*/
-
 	} else {
 		// Windows ASR can not be hardened, since Windows it too old (need at least Windows 10 - 1709)
 		return false

--- a/windowsASR.go
+++ b/windowsASR.go
@@ -78,6 +78,8 @@ func (asr WindowsASRStruct) Harden(harden bool) error {
 			if err != nil {
 				return errors.New("!! Executing powershell cmdlet Set-MpPreference failed.\n")
 			}
+		} else {
+			Info.Println("Windows ASR not activated, since it needs at least Windows 10 - 1709")
 		}
 	} else {
 		// restore (but only if we have at least Windows 10 - 1709)

--- a/windowsASR.go
+++ b/windowsASR.go
@@ -29,6 +29,7 @@ More details here:
 */
 
 import (
+	"errors"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -74,7 +75,7 @@ func (asr WindowsASRStruct) Harden(harden bool) error {
 			psString := fmt.Sprintf("Set-MpPreference -AttackSurfaceReductionRules_Ids %s -AttackSurfaceReductionRules_Actions %s", ruleIDEnumeration, actionsEnumeration)
 			_, err := executeCommand("PowerShell.exe", "-Command", psString)
 			if err != nil {
-				return HardenError{"!! Executing powershell cmdlet Set-MpPreference failed.\n"}
+				return errors.New("!! Executing powershell cmdlet Set-MpPreference failed.\n")
 			}
 		}
 	} else {
@@ -85,7 +86,7 @@ func (asr WindowsASRStruct) Harden(harden bool) error {
 			psString := fmt.Sprintf("Remove-MpPreference -AttackSurfaceReductionRules_Ids %s", ruleIDEnumeration)
 			_, err := executeCommand("PowerShell.exe", "-Command", psString)
 			if err != nil {
-				return HardenError{"!! Executing powershell cmdlet Remove-MpPreference failed.\n"}
+				return errors.New("!! Executing powershell cmdlet Remove-MpPreference failed.\n")
 			}
 		}
 	}


### PR DESCRIPTION
This should now be a quite good and stable state, but needs further testing.

Hardentools now logs to hardentools.log in the current directory (Logging can be less verbose for production use). This should also make testing easier.

Also error handling has been improved.

What has to be tested / discussed:
- Test if all hardening is still working (rework might have been subject to Copy&Paste errors) - testers needed
- Redesign GUI (perfect would be to use some icons for each subject (using a red/green status indicator) - proposals needed
- Decide when isHardened() should deliver "true". Only if everything has been hardened (to verify successful hardening) or even if only one thing has been hardened (to be remembered in the registry), to alway allow for a full restore, or both things in different methods?

@botherder Could you first take a look and if you are satisfied we could publish a new "alpha" version and invite some testers via Mattermost?
