### PR TITLE
Hide cmd windows 

### DIFF
--- a/cmdTools.go
+++ b/cmdTools.go
@@ -1,0 +1,32 @@
+// Hardentools
+// Copyright (C) 2017  Security Without Borders
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// helper method for executing cmd commands (does not open cmd window)
+func executeCommand(cmd string, args ...string) (string, error) {
+	var out []byte
+	command := exec.Command(cmd, args...)
+	command.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
+	out, err := command.CombinedOutput()
+
+	return string(out), err
+}

--- a/explorer.go
+++ b/explorer.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"fmt"
-	"os/exec"
 
 	"golang.org/x/sys/windows/registry"
 )
@@ -76,7 +75,7 @@ func (explAssoc ExplorerAssociations) Harden(harden bool) error {
 			// Step 1: Reassociate system wide default
 			// TODO: only reassoc extensions that were also there before hardening
 			assocString := fmt.Sprintf("assoc %s=%s", extension.ext, extension.assoc)
-			_, err := exec.Command("cmd.exe", "/E:ON", "/C", assocString).Output()
+			_, err := executeCommand("cmd.exe", "/E:ON", "/C", assocString)
 			if err != nil {
 				Trace.Println("Error during reassociation of file extension " + extension.ext + ": " + err.Error())
 				lastError = err
@@ -106,7 +105,7 @@ func (explAssoc ExplorerAssociations) Harden(harden bool) error {
 
 			// Step 1: Remove association (system wide default)
 			assocString := fmt.Sprintf("assoc %s=", extension.ext)
-			_, err2 := exec.Command("cmd.exe", "/E:ON", "/C", assocString).Output()
+			_, err2 := executeCommand("cmd.exe", "/E:ON", "/C", assocString)
 			if err2 != nil {
 				Info.Println("Executing ", assocString, " failed")
 				return err2
@@ -138,7 +137,7 @@ func (explAssoc ExplorerAssociations) IsHardened() (isHardened bool) {
 		// user settings are restored automatically when user first opens such
 		// a file
 		assocString := fmt.Sprintf("assoc %s", extension.ext)
-		out, err := exec.Command("cmd.exe", "/E:ON", "/C", assocString).Output()
+		out, err := executeCommand("cmd.exe", "/E:ON", "/C", assocString)
 		if err != nil {
 			Trace.Printf("isHardened?: (ok) %s (output = %s)(error=%s)", assocString, string(out[:]), err.Error())
 			hardened = true

--- a/windowsASR.go
+++ b/windowsASR.go
@@ -34,7 +34,6 @@ More details here:
 import (
 	"errors"
 	"fmt"
-	"os/exec"
 	"strings"
 
 	"golang.org/x/sys/windows/registry"
@@ -246,13 +245,4 @@ func checkWindowsVersion() bool {
 	}
 
 	return true
-}
-
-// helper method for executing powershell commands
-func executeCommand(cmd string, args ...string) (string, error) {
-	var out []byte
-	command := exec.Command(cmd, args...)
-	out, err := command.CombinedOutput()
-
-	return string(out), err
 }


### PR DESCRIPTION
Hides cmd.exe and powershell windows now. One method for all needs is in cmdTools.go now.