### PR TITLE
Office DDE improvements and better save&restore of registry values

### DIFF
--- a/harden_interface.go
+++ b/harden_interface.go
@@ -18,10 +18,10 @@ package main
 
 // HardenInterface is the general interface which should be used for every harden subject
 type HardenInterface interface {
-	IsHardened()  bool   // returns true if harden subject is already completely hardened
-	Harden(bool)  error  // hardens the harden subject if parameter is true, restores it if parameter is false
-	Name()        string // returns short name
-	LongName()    string // returns long name
+	IsHardened() bool    // returns true if harden subject is already completely hardened
+	Harden(bool) error   // hardens the harden subject if parameter is true, restores it if parameter is false
+	Name() string        // returns short name
+	LongName() string    // returns long name
 	Description() string // returns description
 }
 

--- a/main.go
+++ b/main.go
@@ -219,6 +219,7 @@ func restoreAll() {
 	// use goroutine to allow lxn/walk to update window
 	go func() {
 		triggerAll(false)
+		restoreSavedRegistryKeys()
 		markStatus(false)
 
 		showInfoDialog("Done!\nI have restored all risky features!\nFor all changes to take effect please restart Windows.")

--- a/main.go
+++ b/main.go
@@ -269,6 +269,7 @@ func hardenDefaultsAgain() {
 	go func() {
 		// restore hardened settings
 		triggerAll(false)
+		restoreSavedRegistryKeys()
 		markStatus(false)
 
 		// reset expertConfig (is set to currently already hardened settings

--- a/main.go
+++ b/main.go
@@ -206,6 +206,7 @@ func hardenAll() {
 	go func() {
 		triggerAll(true)
 		markStatus(true)
+		showStatus()
 
 		showInfoDialog("Done!\nI have hardened all risky features!\nFor all changes to take effect please restart Windows.")
 		os.Exit(0)
@@ -221,6 +222,7 @@ func restoreAll() {
 		triggerAll(false)
 		restoreSavedRegistryKeys()
 		markStatus(false)
+		showStatus()
 
 		showInfoDialog("Done!\nI have restored all risky features!\nFor all changes to take effect please restart Windows.")
 		os.Exit(0)
@@ -251,13 +253,12 @@ func triggerAll(harden bool) {
 				events.AppendText(fmt.Sprintf("\n!! %s %s FAILED !!\n", outputString, hardenSubject.Name()))
 				Info.Printf("Error for operation %s: %s", hardenSubject.Name(), err.Error())
 			} else {
-				Info.Printf("%s %s has been successful", outputString, hardenSubject.Name())
+				Trace.Printf("%s %s has been successful", outputString, hardenSubject.Name())
 			}
 		}
 	}
 
 	events.AppendText("\n")
-	showStatus()
 }
 
 // hardenDefaultsAgain restores the original settings and

--- a/office.go
+++ b/office.go
@@ -89,6 +89,27 @@ var OfficeActiveX = &RegistrySingleValueDWORD{
 
 //// DDE Mitigations for Word, Outlook and Excel
 // Doesn't harden OneNote for now (due to high impact).
+//
+// Microsoft disabled DDE in Word with Office Update ADV170021 update. We make sure
+// that it is in default (disabled) state. This update adds a new Windows registry
+// key that controls the DDE feature's status for the Word app. The default value
+// disables DDE. Here are registry key's values:
+// [HKEY_CURRENT_USER\Software\Microsoft\Office\%s\Word\Security] AllowDDE(DWORD)
+// AllowDDE(DWORD) = 0: To disable DDE. This is the default setting after you install the update.
+// AllowDDE(DWORD) = 1: To allow DDE requests to an already running program, but prevent DDE requests that require another executable program to be launched.
+// AllowDDE(DWORD) = 2: To fully allow DDE requests.
+// On 1/9/2018, Microsoft released an update for Microsoft Office that adds defense-in-depth configuration options to selectively disable the DDE protocol in all supported editions of Microsoft Excel.
+// If you need to change DDE functionality in Excel after installing the update, follow these steps:
+// In the Registry Editor navigate to \HKEY_CURRENT_USER\Software\Microsoft\Office&lt;version>\Excel\Security DisableDDEServerLaunch(DWORD)
+// Set the DWORD value based on your requirements as follows:
+// DisableDDEServerLaunch = 0: Keep DDE server launch settings unchanged from their initial behavior. This is the default setting after you install the update.
+// DisableDDEServerLaunch = 1: Do not display the dialog that allows users to choose whether to launch a specific DDE server. Instead, behave automatically as though the user chose the default choice of NO.
+// In the Registry Editor navigate to \HKEY_CURRENT_USER\Software\Microsoft\Office&lt;version>\Excel\Security DisableDDEServerLookup(DWORD)
+// Set the DWORD value based on your requirements as follows:
+// DisableDDEServerLookup = 0: Keep DDE server lookup settings unchanged from their initial behavior. This is the default setting after you install the update.
+// DisableDDEServerLookup = 1: Disable querying for DDE Server availability - no query attempt will be made to find DDE servers. .
+
+//
 // [HKEY_CURRENT_USER\Software\Microsoft\Office\%s\Word\Options]
 // [HKEY_CURRENT_USER\Software\Microsoft\Office\%s\Word\Options\WordMail] (this one is for Outlook)
 // [HKEY_CURRENT_USER\Software\Microsoft\Office\%s\Excel\Options]
@@ -113,6 +134,45 @@ var pathWord2007 = "Software\\Microsoft\\Office\\12.0\\Word\\Options\\vpref"
 // OfficeDDE contains the registry keys for DDE hardening
 var OfficeDDE = &MultiHardenInterfaces{
 	hardenInterfaces: []HardenInterface{
+		&OfficeRegistryRegExSingleDWORD{
+			RootKey:       registry.CURRENT_USER,
+			PathRegEx:     pathRegExSecurity,
+			ValueName:     "AllowDDE",
+			HardenedValue: 0,
+			OfficeApps:    []string{"Word"},
+			OfficeVersions: []string{
+				"14.0", // Office 2010
+				"15.0", // Office 2013
+				"16.0", // Office 2016
+			},
+			shortName: "OfficeDDE_AllowDDE_Word",
+		},
+		&OfficeRegistryRegExSingleDWORD{
+			RootKey:       registry.CURRENT_USER,
+			PathRegEx:     pathRegExSecurity,
+			ValueName:     "DisableDDEServerLaunch",
+			HardenedValue: 0,
+			OfficeApps:    []string{"Excel"},
+			OfficeVersions: []string{
+				"14.0", // Office 2010
+				"15.0", // Office 2013
+				"16.0", // Office 2016
+			},
+			shortName: "OfficeDDE_DDEServer_Excel1",
+		},
+		&OfficeRegistryRegExSingleDWORD{
+			RootKey:       registry.CURRENT_USER,
+			PathRegEx:     pathRegExSecurity,
+			ValueName:     "DisableDDEServerLookup",
+			HardenedValue: 0,
+			OfficeApps:    []string{"Excel"},
+			OfficeVersions: []string{
+				"14.0", // Office 2010
+				"15.0", // Office 2013
+				"16.0", // Office 2016
+			},
+			shortName: "OfficeDDE_DDEServer_Excel2",
+		},
 		&OfficeRegistryRegExSingleDWORD{
 			RootKey:       registry.CURRENT_USER,
 			PathRegEx:     pathRegExOptions,

--- a/office.go
+++ b/office.go
@@ -132,8 +132,12 @@ var pathRegExSecurity = "Software\\Microsoft\\Office\\%s\\%s\\Security"
 var pathWord2007 = "Software\\Microsoft\\Office\\12.0\\Word\\Options\\vpref"
 
 // OfficeDDE contains the registry keys for DDE hardening
+// please also refer to
+// https://docs.microsoft.com/en-us/security-updates/securityadvisories/2017/4053440
 var OfficeDDE = &MultiHardenInterfaces{
 	hardenInterfaces: []HardenInterface{
+		// AllowDDE: part of Update ADV170021
+		// disables DDE for Word (default setting after installation of update)
 		&OfficeRegistryRegExSingleDWORD{
 			RootKey:       registry.CURRENT_USER,
 			PathRegEx:     pathRegExSecurity,
@@ -147,32 +151,99 @@ var OfficeDDE = &MultiHardenInterfaces{
 			},
 			shortName: "OfficeDDE_AllowDDE_Word",
 		},
+		// DisableDDEServerLaunch: part of  Update ADV170021
+		// "0" reflects Microsoft standard settings. If you want to further harden
+		// your settings you could use "1" and uncomment this
+		//&OfficeRegistryRegExSingleDWORD{
+		//	RootKey:       registry.CURRENT_USER,
+		//	PathRegEx:     pathRegExSecurity,
+		//	ValueName:     "DisableDDEServerLaunch",
+		//	HardenedValue: 0,
+		//	OfficeApps:    []string{"Excel"},
+		//	OfficeVersions: []string{
+		//		"14.0", // Office 2010
+		//		"15.0", // Office 2013
+		//		"16.0", // Office 2016
+		//	},
+		//	shortName: "OfficeDDE_DDEServer_Excel1",
+		//},
+		// DisableDDEServerLookup: part of  Update ADV170021
+		// "0" reflects Microsoft standard settings. If you want to further harden
+		// your settings you could use "1" and uncomment this
+		//&OfficeRegistryRegExSingleDWORD{
+		//	RootKey:       registry.CURRENT_USER,
+		//	PathRegEx:     pathRegExSecurity,
+		//	ValueName:     "DisableDDEServerLookup",
+		//	HardenedValue: 0,
+		//	OfficeApps:    []string{"Excel"},
+		//	OfficeVersions: []string{
+		//		"14.0", // Office 2010
+		//		"15.0", // Office 2013
+		//		"16.0", // Office 2016
+		//	},
+		//	shortName: "OfficeDDE_DDEServer_Excel2",
+		//},
+		// the following setting has been removed, because it causes excel files
+		// that are opened in Windows Explorer not loading anymore (excel is
+		// started, but file is not opened (which is very inconvenient/unexpected)
+		// -> https://social.technet.microsoft.com/Forums/en-US/ec1d2f20-ec8a-4c3b-
+		//    9e1b-ee731981db7c/double-clicking-xlsx-files-opens-a-blank-excel-page
+		//&OfficeRegistryRegExSingleDWORD{
+		//	RootKey:        registry.CURRENT_USER,
+		//	PathRegEx:      pathRegExOptions,
+		//	ValueName:      "DDEAllowed",
+		//	HardenedValue:  0,
+		//	OfficeApps:     []string{"Excel"},
+		//	OfficeVersions: standardOfficeVersions,
+		//	shortName:      "OfficeDDE_DDEAllowedExcel",
+		//},
+		// the following setting has been removed, because it causes excel files
+		// that are opened in Windows Explorer not loading anymore (excel is
+		// started, but file is not opened (which is very inconvenient/unexpected)
+		// -> https://social.technet.microsoft.com/Forums/en-US/ec1d2f20-ec8a-4c3b-
+		//    9e1b-ee731981db7c/double-clicking-xlsx-files-opens-a-blank-excel-page
+		//&OfficeRegistryRegExSingleDWORD{
+		//	RootKey:        registry.CURRENT_USER,
+		//	PathRegEx:      pathRegExOptions,
+		//	ValueName:      "DDECleaned",
+		//	HardenedValue:  1,
+		//	OfficeApps:     []string{"Excel"},
+		//	OfficeVersions: standardOfficeVersions,
+		//	shortName:      "OfficeDDE_DDECleanedExcel",
+		//},
+		// the following setting has been removed, because it causes excel files
+		// that are opened in Windows Explorer not loading anymore (excel is
+		// started, but file is not opened (which is very inconvenient/unexpected)
+		//&OfficeRegistryRegExSingleDWORD{
+		//	RootKey:        registry.CURRENT_USER,
+		//	PathRegEx:      pathRegExOptions,
+		//	ValueName:      "Options",
+		//	HardenedValue:  0x117,
+		//	OfficeApps:     []string{"Excel"},
+		//	OfficeVersions: standardOfficeVersions,
+		//	shortName:      "OfficeDDE_OptionsExcel",
+		//},
+
+		// WorkbookLinkWarnings
+		// Impact of mitigation: Disabling this feature could prevent Excel
+		// spreadsheets from updating dynamically if disabled in the registry.
+		// Data might not be completely up-to-date because it is no longer being
+		// updated automatically via live feed. To update the worksheet, the user
+		// must start the feed manually. In addition, the user will not receive
+		// prompts to remind them to manually update the worksheet.
 		&OfficeRegistryRegExSingleDWORD{
-			RootKey:       registry.CURRENT_USER,
-			PathRegEx:     pathRegExSecurity,
-			ValueName:     "DisableDDEServerLaunch",
-			HardenedValue: 0,
-			OfficeApps:    []string{"Excel"},
-			OfficeVersions: []string{
-				"14.0", // Office 2010
-				"15.0", // Office 2013
-				"16.0", // Office 2016
-			},
-			shortName: "OfficeDDE_DDEServer_Excel1",
+			RootKey:        registry.CURRENT_USER,
+			PathRegEx:      pathRegExSecurity,
+			ValueName:      "WorkbookLinkWarnings",
+			HardenedValue:  2,
+			OfficeApps:     []string{"Excel"},
+			OfficeVersions: standardOfficeVersions,
+			shortName:      "OfficeDDE_WorkbookLinksExcel",
 		},
-		&OfficeRegistryRegExSingleDWORD{
-			RootKey:       registry.CURRENT_USER,
-			PathRegEx:     pathRegExSecurity,
-			ValueName:     "DisableDDEServerLookup",
-			HardenedValue: 0,
-			OfficeApps:    []string{"Excel"},
-			OfficeVersions: []string{
-				"14.0", // Office 2010
-				"15.0", // Office 2013
-				"16.0", // Office 2016
-			},
-			shortName: "OfficeDDE_DDEServer_Excel2",
-		},
+		// fNoCalclinksOnopen_90_1 & DontUpdateLinks:
+		// Impact of mitigation: Setting this registry key will disable automatic
+		// update for DDE field and OLE links. Users can still enable the update by
+		// right-clicking on the field and clicking “Update Field”.
 		&OfficeRegistryRegExSingleDWORD{
 			RootKey:       registry.CURRENT_USER,
 			PathRegEx:     pathRegExOptions,
@@ -199,42 +270,6 @@ var OfficeDDE = &MultiHardenInterfaces{
 			},
 			shortName: "OfficeDDE_DontUpdateLinksWordMail",
 		},
-		&OfficeRegistryRegExSingleDWORD{
-			RootKey:        registry.CURRENT_USER,
-			PathRegEx:      pathRegExOptions,
-			ValueName:      "DDEAllowed",
-			HardenedValue:  0,
-			OfficeApps:     []string{"Excel"},
-			OfficeVersions: standardOfficeVersions,
-			shortName:      "OfficeDDE_DDEAllowedExcel",
-		},
-		&OfficeRegistryRegExSingleDWORD{
-			RootKey:        registry.CURRENT_USER,
-			PathRegEx:      pathRegExOptions,
-			ValueName:      "DDECleaned",
-			HardenedValue:  1,
-			OfficeApps:     []string{"Excel"},
-			OfficeVersions: standardOfficeVersions,
-			shortName:      "OfficeDDE_DDECleanedExcel",
-		},
-		&OfficeRegistryRegExSingleDWORD{
-			RootKey:        registry.CURRENT_USER,
-			PathRegEx:      pathRegExOptions,
-			ValueName:      "Options",
-			HardenedValue:  0x117,
-			OfficeApps:     []string{"Excel"},
-			OfficeVersions: standardOfficeVersions,
-			shortName:      "OfficeDDE_OptionsExcel",
-		},
-		&OfficeRegistryRegExSingleDWORD{
-			RootKey:        registry.CURRENT_USER,
-			PathRegEx:      pathRegExSecurity,
-			ValueName:      "WorkbookLinkWarnings",
-			HardenedValue:  2,
-			OfficeApps:     []string{"Excel"},
-			OfficeVersions: standardOfficeVersions,
-			shortName:      "OfficeDDE_WorkbookLinksExcel",
-		},
 		&RegistrySingleValueDWORD{
 			RootKey:       registry.CURRENT_USER,
 			Path:          pathWord2007,
@@ -244,7 +279,7 @@ var OfficeDDE = &MultiHardenInterfaces{
 		},
 	},
 	shortName: "OfficeDDE",
-	longName:  "Office DDE  Links",
+	longName:  "Office DDE Mitigations",
 }
 
 //// HardenInterface methods

--- a/registry_utils.go
+++ b/registry_utils.go
@@ -130,10 +130,87 @@ func (regMultiValue *RegistryMultiValue) Description() string {
 }
 
 ////
+// helper methods
+// get root key name (LOCAL_MACHINE vs. LOCAL_USER)
+func getRootKeyName(rootKey registry.Key) (rootKeyName string, err error) {
+	// this is kind of a hack, since registry.Key doesn't allow to get the
+	// name of the key itself
+	switch rootKey {
+	case registry.CLASSES_ROOT:
+		rootKeyName = "CLASSES_ROOT"
+	case registry.CURRENT_USER:
+		rootKeyName = "CURRENT_USER"
+	case registry.LOCAL_MACHINE:
+		rootKeyName = "LOCAL_MACHINE"
+	case registry.USERS:
+		rootKeyName = "USERS"
+	case registry.CURRENT_CONFIG:
+		rootKeyName = "CURRENT_CONFIG"
+	case registry.PERFORMANCE_DATA:
+		rootKeyName = "PERFORMANCE_DATA"
+	default:
+		// invalid rootKey?
+		Info.Println("Invalid rootKey provided to save registry function")
+		err = errors.New("Invalid rootKey provided to save registry function")
+	}
+	return
+}
+
+// get root key from name (LOCAL_MACHINE vs. LOCAL_USER)
+func getRootKeyFromName(rootKeyName string) (rootKey registry.Key, err error) {
+	switch rootKeyName {
+	case "CLASSES_ROOT":
+		rootKey = registry.CLASSES_ROOT
+	case "CURRENT_USER":
+		rootKey = registry.CURRENT_USER
+	case "LOCAL_MACHINE":
+		rootKey = registry.LOCAL_MACHINE
+	case "USERS":
+		rootKey = registry.USERS
+	case "CURRENT_CONFIG":
+		rootKey = registry.CURRENT_CONFIG
+	case "PERFORMANCE_DATA":
+		rootKey = registry.PERFORMANCE_DATA
+	default:
+		// invalid rootKeyName?
+		Info.Println("Invalid rootKeyName provided to restore registry function")
+		err = errors.New("Invalid rootKeyName provided to restore registry function")
+		return registry.CURRENT_USER, err
+	}
+	return rootKey, nil
+}
+
+////
+// harden Dword value including saving the original state
+func hardenKey(rootKey registry.Key, path string, valueName string, hardenedValue uint32) error {
+	rootKeyName, _ := getRootKeyName(rootKey)
+	key, _, err := registry.CreateKey(rootKey, path, registry.WRITE)
+	if err != nil {
+		return fmt.Errorf("Couldn't create / open registry key for write access: %s\\%s", rootKeyName, path)
+	}
+	defer key.Close()
+
+	// Save current state.
+	err = saveOriginalRegistryDWORD(rootKey, path, valueName)
+	if err != nil {
+		return err
+	}
+	// Harden.
+	err = key.SetDWordValue(valueName, hardenedValue)
+	if err != nil {
+		return fmt.Errorf("Couldn't set registry value: %s \\ %s \\ %s", rootKeyName, path, valueName)
+	}
+
+	return nil
+}
+
+////
 // save and restore methods
 
 // helper method for saving original registry key.
 func saveOriginalRegistryDWORD(rootKey registry.Key, keyName string, valueName string) error {
+	saveNonExisting := false
+
 	// open hardentools root key
 	hardentoolsKey, _, err := registry.CreateKey(registry.CURRENT_USER, hardentoolsKeyPath, registry.ALL_ACCESS)
 	if err != nil {
@@ -141,32 +218,74 @@ func saveOriginalRegistryDWORD(rootKey registry.Key, keyName string, valueName s
 	}
 	defer hardentoolsKey.Close()
 
-	// get value of registry key to save
-	keyToSave, err := registry.OpenKey(rootKey, keyName, registry.READ)
-	if err != nil {
-		Info.Println("Could not open registry key to save due to error: " + err.Error())
-		return err
-	}
-	defer keyToSave.Close()
-
-	// now finally get value to save
-	originalValue, _, err := keyToSave.GetIntegerValue(valueName)
-	if err != nil {
-		Info.Println("Could not retrieve value of registry key to save (" + keyName + ", " + valueName + ") due to error: " + err.Error())
-		return nil // nothing to save (no error, normal behaviour if registry key was not set)
-	}
-
-	// get name of root ke (e.g. CURRENT_USER)
+	// get name of root key (e.g. CURRENT_USER)
 	rootKeyName, err := getRootKeyName(rootKey)
 	if err != nil {
 		return err
 	}
 
-	// save value
-	Trace.Println("Saving value for: " + "SavedState_" + rootKeyName + "\\" + keyName + "_" + valueName)
-	err = hardentoolsKey.SetDWordValue("SavedState_"+rootKeyName+"\\"+keyName+"_"+valueName, uint32(originalValue))
+	// open registry key
+	keyToSave, err := registry.OpenKey(rootKey, keyName, registry.READ)
 	if err != nil {
-		Info.Println("Could not save state")
+		Trace.Println("Could not open registry key to save due to error: " + err.Error())
+		saveNonExisting = true
+	} else {
+		defer keyToSave.Close()
+
+		// now finally get value to save
+		originalValue, _, err := keyToSave.GetIntegerValue(valueName)
+		if err != nil {
+			Trace.Println("Could not retrieve registry value to save (" + keyName + ", " + valueName + ") due to error: " + err.Error())
+			saveNonExisting = true
+		} else {
+			// save value
+			Trace.Println("Saving value for: " + "SavedStateNew_" + rootKeyName + "\\" + keyName + "_" + valueName)
+			err = hardentoolsKey.SetDWordValue("SavedStateNew_"+rootKeyName+"\\"+keyName+"____"+valueName, uint32(originalValue))
+			if err != nil {
+				Info.Println("Could not save state due to error: " + err.Error())
+			}
+		}
+	}
+
+	if saveNonExisting {
+		// save as not existing before hardening
+		Trace.Println("Saving " + rootKeyName + "\\" + keyName + "_" + valueName + " as not existing before hardening")
+		err = hardentoolsKey.SetDWordValue("SavedStateNotExisting_"+rootKeyName+"\\"+keyName+"____"+valueName, 0)
+		if err != nil {
+			Info.Println("Could not save state due to error: " + err.Error())
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Helper method for restoring original state of a DWORD registry key.
+// TODO: remove this method and replace with restoreSavedRegistryKeys
+//       in future version (see inline comment)
+func restoreKey(rootKey registry.Key, keyName string, valueName string) (err error) {
+	// open key to be restored
+	key, err := registry.OpenKey(rootKey, keyName, registry.ALL_ACCESS)
+	if err != nil {
+		Info.Println("Could not open registry key " + keyName + " due to error: " + err.Error())
+		return err
+	}
+	defer key.Close()
+
+	// get original state value
+	value, err := retrieveOriginalRegistryDWORD(rootKey, keyName, valueName)
+	if err == nil {
+		Info.Printf("Restore: Restoring registry value %s\\%s = %d", keyName, valueName, value)
+		err = key.SetDWordValue(valueName, value)
+	} else {
+		// TODO: here it is assumed that registry keys which were not safed did not
+		// exist during hardening. This assumption is from old versions of
+		// hardentools and still included to beeing able to restore old hardens
+		// with the current version of hardentools. Since this would also lead
+		// to settings beeing deleted when introducing new functionality in
+		// hardentools, this will be removed in upcoming versions
+		Info.Println("Restore: Could not get saved reg. value, deleting " + keyName + "\\" + valueName)
+		err = key.DeleteValue(valueName)
 	}
 	return err
 }
@@ -196,79 +315,7 @@ func retrieveOriginalRegistryDWORD(rootKey registry.Key, keyName string, valueNa
 	return uint32(value64), nil
 }
 
-// Helper method for restoring original state of a DWORD registry key.
-func restoreKey(rootKey registry.Key, keyName string, valueName string) (err error) {
-	/*// open key to be restored
-	key, err := registry.OpenKey(rootKey, keyName, registry.ALL_ACCESS)
-	if err != nil {
-		Info.Println("Could not open registry key " + keyName + " due to error: " + err.Error())
-		return err
-	}
-	defer key.Close()
-
-	// get original state value
-	value, err := retrieveOriginalRegistryDWORD(rootKey, keyName, valueName)
-	if err == nil {
-		Info.Printf("Restore: Restoring registry value %s\\%s = %d", keyName, valueName, value)
-		err = key.SetDWordValue(valueName, value)
-	} else {
-		Info.Println("Restore: Could not get saved reg. value, deleting " + keyName + "\\" + valueName)
-		err = key.DeleteValue(valueName)
-	}
-	return err*/
-	return nil
-}
-
-// get root key name (LOCAL_MACHINE vs. LOCAL_USER)
-func getRootKeyName(rootKey registry.Key) (rootKeyName string, err error) {
-	// this is kind of a hack, since registry.Key doesn't allow to get the
-	// name of the key itself
-
-	switch rootKey {
-	case registry.CLASSES_ROOT:
-		rootKeyName = "CLASSES_ROOT"
-	case registry.CURRENT_USER:
-		rootKeyName = "CURRENT_USER"
-	case registry.LOCAL_MACHINE:
-		rootKeyName = "LOCAL_MACHINE"
-	case registry.USERS:
-		rootKeyName = "USERS"
-	case registry.CURRENT_CONFIG:
-		rootKeyName = "CURRENT_CONFIG"
-	case registry.PERFORMANCE_DATA:
-		rootKeyName = "PERFORMANCE_DATA"
-	default:
-		// invalid rootKey?
-		Info.Println("Invalid rootKey provided to save registry function")
-		err = errors.New("Invalid rootKey provided to save registry function")
-	}
-
-	return
-}
-
-// harden Dword value including saving the original state
-func hardenKey(rootKey registry.Key, path string, valueName string, hardenedValue uint32) error {
-	rootKeyName, _ := getRootKeyName(rootKey)
-	key, _, err := registry.CreateKey(rootKey, path, registry.WRITE)
-	if err != nil {
-		return fmt.Errorf("Couldn't create / open registry key for write access: %s\\%s", rootKeyName, path)
-	}
-	defer key.Close()
-
-	// Save current state.
-	err = saveOriginalRegistryDWORD(rootKey, path, valueName)
-	if err != nil {
-		return err
-	}
-	// Harden.
-	err = key.SetDWordValue(valueName, hardenedValue)
-	if err != nil {
-		return fmt.Errorf("Couldn't set registry value: %s \\ %s \\ %s", rootKeyName, path, valueName)
-	}
-
-	return nil
-}
-
+// restoreSavedRegistryKeys restores all saved registry keys from their saved registry state
 func restoreSavedRegistryKeys() error {
 	// open hardentools root key
 	hardentoolsKey, err := registry.OpenKey(registry.CURRENT_USER, hardentoolsKeyPath, registry.QUERY_VALUE)
@@ -292,31 +339,82 @@ func restoreSavedRegistryKeys() error {
 		}
 		settings[param] = val
 	}
-	Trace.Printf("%#v\n", settings)
+	//Trace.Printf("%#v\n", settings)
 
 	for regKey, regValue := range settings {
 		if strings.HasPrefix(regKey, "SavedState_") {
-			// trim SavedState_ string
+			// TODO: this section can be removed in future versions
 			regKey = strings.TrimPrefix(regKey, "SavedState_")
 			rootKeyName := strings.Split(regKey, "\\")[0]
 			regKey = strings.TrimPrefix(regKey, rootKeyName)
 			regKey = strings.TrimPrefix(regKey, "\\")
 			valueName := regKey[strings.LastIndex(regKey, "_")+1:]
 			regKey = strings.TrimSuffix(regKey, "_"+valueName)
-			Trace.Printf("rootKey = %s; regKey = %s; valueName = %s; regValue = %d\n", rootKeyName, regKey, valueName, regValue)
+			Trace.Printf("to be restored: %s\\%s\\%s = %d\n", rootKeyName, regKey, valueName, regValue)
 
-			/*key, err := registry.OpenKey(rootKeyName, regKey, registry.ALL_ACCESS)
-			if err != nil {
-				Info.Println("Could not open registry key " + keyName + " due to error: " + err.Error())
-				return err
+			rootKey, err := getRootKeyFromName(rootKeyName)
+			if err == nil {
+				key, err := registry.OpenKey(rootKey, regKey, registry.ALL_ACCESS)
+				if err != nil {
+					Info.Println("Could not open registry key " + regKey + " due to error: " + err.Error())
+				} else {
+					defer key.Close()
+
+					Info.Printf("restoreSavedRegistryKeys: Restoring registry value %s\\%s = %d", regKey, valueName, regValue)
+					err = key.SetDWordValue(valueName, uint32(regValue))
+					if err != nil {
+						Info.Printf("Could not restore registry value %s\\%s = %d due to error: %s\n", regKey, valueName, regValue, err.Error())
+					}
+				}
 			}
-			defer key.Close()
+		} else if strings.HasPrefix(regKey, "SavedStateNew_") {
+			regKey = strings.TrimPrefix(regKey, "SavedStateNew_")
+			rootKeyName := strings.Split(regKey, "\\")[0]
+			regKey = strings.TrimPrefix(regKey, rootKeyName)
+			regKey = strings.TrimPrefix(regKey, "\\")
+			valueName := regKey[strings.LastIndex(regKey, "____")+4:]
+			regKey = strings.TrimSuffix(regKey, "____"+valueName)
+			Trace.Printf("to be restored: %s\\%s\\%s = %d\n", rootKeyName, regKey, valueName, regValue)
 
-			Info.Printf("Restore: Restoring registry value %s\\%s = %d", regKey, valueName, value)
-			err = key.SetDWordValue(valueName, value)
-			return err*/
+			rootKey, err := getRootKeyFromName(rootKeyName)
+			if err == nil {
+				key, err := registry.OpenKey(rootKey, regKey, registry.ALL_ACCESS)
+				if err != nil {
+					Info.Println("Could not open registry key " + regKey + " due to error: " + err.Error())
+				} else {
+					defer key.Close()
+
+					Info.Printf("restoreSavedRegistryKeys: Restoring registry value %s\\%s = %d", regKey, valueName, regValue)
+					err = key.SetDWordValue(valueName, uint32(regValue))
+					if err != nil {
+						Info.Printf("Could not restore registry value %s\\%s = %d due to error: %s\n", regKey, valueName, regValue, err.Error())
+					}
+				}
+			}
+		} else if strings.HasPrefix(regKey, "SavedStateNotExisting_") {
+			regKey = strings.TrimPrefix(regKey, "SavedStateNotExisting_")
+			rootKeyName := strings.Split(regKey, "\\")[0]
+			regKey = strings.TrimPrefix(regKey, rootKeyName)
+			regKey = strings.TrimPrefix(regKey, "\\")
+			valueName := regKey[strings.LastIndex(regKey, "____")+4:]
+			regKey = strings.TrimSuffix(regKey, "____"+valueName)
+			Trace.Printf("to be restored (deleted): %s\\%s\\%s\n", rootKeyName, regKey, valueName)
+
+			rootKey, err := getRootKeyFromName(rootKeyName)
+			if err == nil {
+				key, err := registry.OpenKey(rootKey, regKey, registry.ALL_ACCESS)
+				if err != nil {
+					Info.Println("Could not open registry key " + regKey + " due to error: " + err.Error())
+				} else {
+					defer key.Close()
+
+					err = key.DeleteValue(valueName)
+					if err != nil {
+						Info.Printf("Could not restore registry value (by deleting) %s\\%s due to error: %s\n", regKey, valueName, err.Error())
+					}
+				}
+			}
 		}
 	}
-	return nil
-
+	return err
 }

--- a/registry_utils.go
+++ b/registry_utils.go
@@ -19,6 +19,7 @@ package main
 import (
 	"errors"
 	"fmt"
+
 	"golang.org/x/sys/windows/registry"
 )
 
@@ -265,3 +266,33 @@ func hardenKey(rootKey registry.Key, path string, valueName string, hardenedValu
 
 	return nil
 }
+
+/*
+func restoreSavedRegistryKeys() error {
+	// open hardentools root key
+	hardentoolsKey, _, err := registry.CreateKey(registry.CURRENT_USER, hardentoolsKeyPath, registry.ALL_ACCESS)
+	if err != nil {
+		return 0, err
+	}
+	defer hardentoolsKey.Close()
+
+	registry.
+		hardentoolsKey
+
+	// get rootKeyName
+	rootKeyName, err := getRootKeyName(rootKey)
+	if err != nil {
+		Info.Println("Could not get rootKeyName")
+		return 0, err
+	}
+
+	// get saved state
+	value64, _, err := hardentoolsKey.GetIntegerValue("SavedState_" + rootKeyName + "\\" + keyName + "_" + valueName)
+	if err != nil {
+		return 0, err
+	}
+
+	return uint32(value64), nil
+
+}
+*/


### PR DESCRIPTION
This PR includes:
- Removes high impact Excel DDE mitigations (double clicking an Excel file did not work anymore)
- added registry keys for Microsofts Word and Excel DDE patches, fixes #63  
- better save&restore of registry values (now also remembers values that did not exist before and removes them. This fixes the problem that hardening measures (like Excel DDE above) are removed from hardentools, these are also restored when doing the restore with a newer version).