### PR TITLE
Re-Adds possibility to make harden objects optional

### DIFF
--- a/adobe.go
+++ b/adobe.go
@@ -29,14 +29,15 @@ var standardAdobeVersions = []string{
 
 // AdobeRegistryRegExSingleDWORD is the data type for a RegEx Path / Single Value DWORD combination
 type AdobeRegistryRegExSingleDWORD struct {
-	RootKey       registry.Key
-	PathRegEx     string
-	ValueName     string
-	HardenedValue uint32
-	AdobeVersions []string
-	shortName     string
-	longName      string
-	description   string
+	RootKey         registry.Key
+	PathRegEx       string
+	ValueName       string
+	HardenedValue   uint32
+	AdobeVersions   []string
+	shortName       string
+	longName        string
+	description     string
+	hardenByDefault bool
 }
 
 // AdobePDFJS hardens Acrobat JavaScript
@@ -44,14 +45,15 @@ type AdobeRegistryRegExSingleDWORD struct {
 // 0 - Disable AcroJS
 // 1 - Enable AcroJS
 var AdobePDFJS = &AdobeRegistryRegExSingleDWORD{
-	RootKey:       registry.CURRENT_USER,
-	PathRegEx:     "SOFTWARE\\Adobe\\Acrobat Reader\\%s\\JSPrefs",
-	ValueName:     "bEnableJS",
-	HardenedValue: 0, // Disable AcroJS
-	AdobeVersions: standardAdobeVersions,
-	shortName:     "AdobePDFJS",
-	longName:      "Acrobat Reader JavaScript",
-	description:   "Disables Acrobat Reader JavaScript",
+	RootKey:         registry.CURRENT_USER,
+	PathRegEx:       "SOFTWARE\\Adobe\\Acrobat Reader\\%s\\JSPrefs",
+	ValueName:       "bEnableJS",
+	HardenedValue:   0, // Disable AcroJS
+	AdobeVersions:   standardAdobeVersions,
+	shortName:       "AdobePDFJS",
+	longName:        "Acrobat Reader JavaScript",
+	description:     "Disables Acrobat Reader JavaScript",
+	hardenByDefault: true,
 }
 
 // AdobePDFObjects hardens Adobe Reader Embedded Objects
@@ -77,9 +79,10 @@ var AdobePDFObjects = &MultiHardenInterfaces{
 			shortName:     "AdobePDFObjects_bSecureOpenFile",
 		},
 	},
-	shortName:   "AdobePDFObjects",
-	longName:    "Acrobat Reader Embedded Objects",
-	description: "Disables Acrobat Reader embedded objects",
+	shortName:       "AdobePDFObjects",
+	longName:        "Acrobat Reader Embedded Objects",
+	description:     "Disables Acrobat Reader embedded objects",
+	hardenByDefault: true,
 }
 
 // AdobePDFProtectedMode switches on the Protected Mode setting under "Security (Enhanced)" (enabled by default in current versions)
@@ -87,14 +90,15 @@ var AdobePDFObjects = &MultiHardenInterfaces{
 // 0 - Disable Protected Mode
 // 1 - Enable Protected Mode
 var AdobePDFProtectedMode = &AdobeRegistryRegExSingleDWORD{
-	RootKey:       registry.CURRENT_USER,
-	PathRegEx:     "SOFTWARE\\Adobe\\Acrobat Reader\\%s\\Privileged",
-	ValueName:     "bProtectedMode",
-	HardenedValue: 1,
-	AdobeVersions: standardAdobeVersions,
-	shortName:     "AdobePDFProtectedMode",
-	longName:      "Acrobat Reader Protected Mode",
-	description:   "Enables Acrobat Reader Protected Mode",
+	RootKey:         registry.CURRENT_USER,
+	PathRegEx:       "SOFTWARE\\Adobe\\Acrobat Reader\\%s\\Privileged",
+	ValueName:       "bProtectedMode",
+	HardenedValue:   1,
+	AdobeVersions:   standardAdobeVersions,
+	shortName:       "AdobePDFProtectedMode",
+	longName:        "Acrobat Reader Protected Mode",
+	description:     "Enables Acrobat Reader Protected Mode",
+	hardenByDefault: true,
 }
 
 // AdobePDFProtectedView switches on Protected View for all files from untrusted sources
@@ -102,23 +106,25 @@ var AdobePDFProtectedMode = &AdobeRegistryRegExSingleDWORD{
 // 0 - Disable Protected View
 // 1 - Enable Protected View
 var AdobePDFProtectedView = &AdobeRegistryRegExSingleDWORD{
-	RootKey:       registry.CURRENT_USER,
-	PathRegEx:     "SOFTWARE\\Adobe\\Acrobat Reader\\%s\\TrustManager",
-	ValueName:     "iProtectedView",
-	HardenedValue: 1,
-	AdobeVersions: standardAdobeVersions,
-	shortName:     "AdobePDFProtectedView",
-	longName:      "Acrobat Reader Protected View",
-	description:   "Enables Acrobat Reader Protected View",
+	RootKey:         registry.CURRENT_USER,
+	PathRegEx:       "SOFTWARE\\Adobe\\Acrobat Reader\\%s\\TrustManager",
+	ValueName:       "iProtectedView",
+	HardenedValue:   1,
+	AdobeVersions:   standardAdobeVersions,
+	shortName:       "AdobePDFProtectedView",
+	longName:        "Acrobat Reader Protected View",
+	description:     "Enables Acrobat Reader Protected View",
+	hardenByDefault: true,
 }
 
 // AdobePDFEnhancedSecurity switches on Enhanced Security setting under "Security (Enhanced)"
 // (enabled by default in current versions)
 // (HKEY_CURRENT_USER\SOFTWARE\Adobe\Acrobat Reader\DC\TrustManager -> bEnhancedSecurityInBrowser = 1 & bEnhancedSecurityStandalone = 1)
 var AdobePDFEnhancedSecurity = &MultiHardenInterfaces{
-	shortName:   "AdobePDFEnhancedSecurity",
-	longName:    "Acrobat Reader Enhanced Security",
-	description: "Enables Acrobat Reader Enhanced Security",
+	shortName:       "AdobePDFEnhancedSecurity",
+	longName:        "Acrobat Reader Enhanced Security",
+	description:     "Enables Acrobat Reader Enhanced Security",
+	hardenByDefault: true,
 	hardenInterfaces: []HardenInterface{
 		&AdobeRegistryRegExSingleDWORD{
 			RootKey:       registry.CURRENT_USER,
@@ -206,4 +212,9 @@ func (adobeRegEx *AdobeRegistryRegExSingleDWORD) LongName() string {
 // Description return description of hardening module
 func (adobeRegEx *AdobeRegistryRegExSingleDWORD) Description() string {
 	return adobeRegEx.description
+}
+
+// HardenByDefault returns if subject should be hardened by default
+func (adobeRegEx *AdobeRegistryRegExSingleDWORD) HardenByDefault() bool {
+	return adobeRegEx.hardenByDefault
 }

--- a/autorun.go
+++ b/autorun.go
@@ -51,6 +51,7 @@ var Autorun = &RegistryMultiValue{
 			shortName:     "Autorun_Autplay",
 		},
 	},
-	shortName: "Autorun",
-	longName:  "AutoRun and AutoPlay",
+	shortName:       "Autorun",
+	longName:        "AutoRun and AutoPlay",
+	hardenByDefault: true,
 }

--- a/explorer.go
+++ b/explorer.go
@@ -45,10 +45,11 @@ type Extension struct {
 
 // ExplorerAssociations is the struct for HardenInterface implementation
 type ExplorerAssociations struct {
-	extensions  []Extension
-	shortName   string
-	longName    string
-	description string
+	extensions      []Extension
+	shortName       string
+	longName        string
+	description     string
+	hardenByDefault bool
 }
 
 // FileAssociations contains all extensions to be removed
@@ -65,8 +66,9 @@ var FileAssociations = ExplorerAssociations{
 		{".VBE", "VBEFile"},
 		{".pif", "piffile"},
 	},
-	shortName: "FileAssociations",
-	longName:  "File associations",
+	shortName:       "FileAssociations",
+	longName:        "File associations",
+	hardenByDefault: true,
 }
 
 // Harden explorer associations
@@ -166,4 +168,9 @@ func (explAssoc ExplorerAssociations) LongName() string {
 // Description of the harden item
 func (explAssoc ExplorerAssociations) Description() string {
 	return explAssoc.description
+}
+
+// HardenByDefault returns if subject should be hardened by default
+func (explAssoc ExplorerAssociations) HardenByDefault() bool {
+	return explAssoc.hardenByDefault
 }

--- a/gui.go
+++ b/gui.go
@@ -88,7 +88,7 @@ func openMainWindow(splashChannel chan bool, elevationStatus bool) {
 
 		if status == false {
 			// all checkboxes checked by default, disabled only if subject is already hardened
-			expertConfig[hardenSubject.Name()] = !subjectIsHardened
+			expertConfig[hardenSubject.Name()] = !subjectIsHardened && hardenSubject.HardenByDefault()
 
 			// only enable, if not already hardenend
 			enableField = !subjectIsHardened

--- a/harden_interface.go
+++ b/harden_interface.go
@@ -18,11 +18,12 @@ package main
 
 // HardenInterface is the general interface which should be used for every harden subject
 type HardenInterface interface {
-	IsHardened() bool    // returns true if harden subject is already completely hardened
-	Harden(bool) error   // hardens the harden subject if parameter is true, restores it if parameter is false
-	Name() string        // returns short name
-	LongName() string    // returns long name
-	Description() string // returns description
+	IsHardened() bool      // returns true if harden subject is already completely hardened
+	Harden(bool) error     // hardens the harden subject if parameter is true, restores it if parameter is false
+	Name() string          // returns short name
+	LongName() string      // returns long name
+	Description() string   // returns description
+	HardenByDefault() bool // returns if this harden subject should be hardened by default or only optional
 }
 
 // MultiHardenInterfaces is a type for an array of HardenInterfaces
@@ -31,6 +32,7 @@ type MultiHardenInterfaces struct {
 	shortName        string
 	longName         string
 	description      string
+	hardenByDefault  bool
 }
 
 // Harden hardens (if harden == true) or restores (if harden == false) MultiHardenInterfaces
@@ -70,4 +72,9 @@ func (mhInterfaces *MultiHardenInterfaces) LongName() string {
 // Description of the harden item
 func (mhInterfaces *MultiHardenInterfaces) Description() string {
 	return mhInterfaces.description
+}
+
+// HardenByDefault returns if subject should be hardened by default
+func (mhInterfaces *MultiHardenInterfaces) HardenByDefault() bool {
+	return mhInterfaces.hardenByDefault
 }

--- a/main.go
+++ b/main.go
@@ -277,9 +277,7 @@ func hardenDefaultsAgain() {
 		// in case of restore
 		expertConfig = make(map[string]bool)
 		for _, hardenSubject := range allHardenSubjects {
-			// TODO: sets all harden subjects to active for now. Better: replace
-			// this with default settings (to be implemented)
-			expertConfig[hardenSubject.Name()] = true
+			expertConfig[hardenSubject.Name()] = hardenSubject.HardenByDefault()
 		}
 
 		// harden all settings

--- a/office.go
+++ b/office.go
@@ -35,15 +35,16 @@ var standardOfficeApps = []string{"Excel", "PowerPoint", "Word"}
 
 // OfficeRegistryRegExSingleDWORD is the data type for a RegEx Path / Single Value DWORD combination
 type OfficeRegistryRegExSingleDWORD struct {
-	RootKey        registry.Key
-	PathRegEx      string
-	ValueName      string
-	HardenedValue  uint32
-	OfficeApps     []string
-	OfficeVersions []string
-	shortName      string
-	longName       string
-	description    string
+	RootKey         registry.Key
+	PathRegEx       string
+	ValueName       string
+	HardenedValue   uint32
+	OfficeApps      []string
+	OfficeVersions  []string
+	shortName       string
+	longName        string
+	description     string
+	hardenByDefault bool
 }
 
 // OfficeOLE hardens Office Packager Objects
@@ -51,14 +52,15 @@ type OfficeRegistryRegExSingleDWORD struct {
 // 1 - Prompt from Office when user clicks, object executes
 // 2 - No prompt, Object does not execute
 var OfficeOLE = &OfficeRegistryRegExSingleDWORD{
-	RootKey:        registry.CURRENT_USER,
-	PathRegEx:      "SOFTWARE\\Microsoft\\Office\\%s\\%s\\Security",
-	ValueName:      "PackagerPrompt",
-	HardenedValue:  2,
-	OfficeApps:     standardOfficeApps,
-	OfficeVersions: standardOfficeVersions,
-	shortName:      "OfficeOLE",
-	longName:       "Office Packager Objects (OLE)",
+	RootKey:         registry.CURRENT_USER,
+	PathRegEx:       "SOFTWARE\\Microsoft\\Office\\%s\\%s\\Security",
+	ValueName:       "PackagerPrompt",
+	HardenedValue:   2,
+	OfficeApps:      standardOfficeApps,
+	OfficeVersions:  standardOfficeVersions,
+	shortName:       "OfficeOLE",
+	longName:        "Office Packager Objects (OLE)",
+	hardenByDefault: true,
 }
 
 // OfficeMacros contains Macro registry keys
@@ -67,24 +69,26 @@ var OfficeOLE = &OfficeRegistryRegExSingleDWORD{
 // 3 - Digitally signed only
 // 4 - Disable all
 var OfficeMacros = &OfficeRegistryRegExSingleDWORD{
-	RootKey:        registry.CURRENT_USER,
-	PathRegEx:      "SOFTWARE\\Microsoft\\Office\\%s\\%s\\Security",
-	ValueName:      "VBAWarnings",
-	HardenedValue:  4,
-	OfficeApps:     standardOfficeApps,
-	OfficeVersions: standardOfficeVersions,
-	shortName:      "OfficeMacros",
-	longName:       "Office Macros",
+	RootKey:         registry.CURRENT_USER,
+	PathRegEx:       "SOFTWARE\\Microsoft\\Office\\%s\\%s\\Security",
+	ValueName:       "VBAWarnings",
+	HardenedValue:   4,
+	OfficeApps:      standardOfficeApps,
+	OfficeVersions:  standardOfficeVersions,
+	shortName:       "OfficeMacros",
+	longName:        "Office Macros",
+	hardenByDefault: true,
 }
 
 // OfficeActiveX contains ActiveX registry keys
 var OfficeActiveX = &RegistrySingleValueDWORD{
-	RootKey:       registry.CURRENT_USER,
-	Path:          "SOFTWARE\\Microsoft\\Office\\Common\\Security",
-	ValueName:     "DisableAllActiveX",
-	HardenedValue: 1,
-	shortName:     "OfficeActiveX",
-	longName:      "Office ActiveX",
+	RootKey:         registry.CURRENT_USER,
+	Path:            "SOFTWARE\\Microsoft\\Office\\Common\\Security",
+	ValueName:       "DisableAllActiveX",
+	HardenedValue:   1,
+	shortName:       "OfficeActiveX",
+	longName:        "Office ActiveX",
+	hardenByDefault: true,
 }
 
 //// DDE Mitigations for Word, Outlook and Excel
@@ -278,8 +282,9 @@ var OfficeDDE = &MultiHardenInterfaces{
 			shortName:     "OfficeDDE_Word2007",
 		},
 	},
-	shortName: "OfficeDDE",
-	longName:  "Office DDE Mitigations",
+	shortName:       "OfficeDDE",
+	longName:        "Office DDE Mitigations",
+	hardenByDefault: true,
 }
 
 //// HardenInterface methods
@@ -350,4 +355,9 @@ func (officeRegEx OfficeRegistryRegExSingleDWORD) LongName() string {
 // Description of the harden item
 func (officeRegEx OfficeRegistryRegExSingleDWORD) Description() string {
 	return officeRegEx.description
+}
+
+// HardenByDefault returns if subject should be hardened by default
+func (officeRegEx OfficeRegistryRegExSingleDWORD) HardenByDefault() bool {
+	return officeRegEx.hardenByDefault
 }

--- a/powershell.go
+++ b/powershell.go
@@ -26,19 +26,20 @@ import (
 
 // PowerShellDisallowRunMembers is the struct for the HardenInterface implementation
 type PowerShellDisallowRunMembers struct {
-	shortName   string
-	longName    string
-	description string
+	shortName       string
+	longName        string
+	description     string
+	hardenByDefault bool
 }
 
 // PowerShell is the struct for hardentools interface that combines registry keys and PowerShellDisallowRunMembers
 var PowerShell = &MultiHardenInterfaces{
-	shortName:   "PowerShell",
-	longName:    "Powershell and cmd.exe",
-	description: "Disables Powershell, Powershell ISE and cmd.exe",
+	shortName:       "PowerShell",
+	longName:        "Powershell and cmd.exe",
+	description:     "Disables Powershell, Powershell ISE and cmd.exe",
+	hardenByDefault: false,
 	hardenInterfaces: []HardenInterface{
-		PowerShellDisallowRunMembers{"PowerShell_DisallowRunMembers", "PowerShell_DisallowRunMembers", "PowerShell_DisallowRunMembers"},
-
+		PowerShellDisallowRunMembers{"PowerShell_DisallowRunMembers", "PowerShell_DisallowRunMembers", "PowerShell_DisallowRunMembers", true},
 		&RegistrySingleValueDWORD{
 			RootKey:       registry.CURRENT_USER,
 			Path:          "Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer",
@@ -175,4 +176,9 @@ func (pwShell PowerShellDisallowRunMembers) LongName() string {
 // Description of the harden item
 func (pwShell PowerShellDisallowRunMembers) Description() string {
 	return pwShell.description
+}
+
+// HardenByDefault returns if subject should be hardened by default
+func (pwShell PowerShellDisallowRunMembers) HardenByDefault() bool {
+	return pwShell.hardenByDefault
 }

--- a/powershell.go
+++ b/powershell.go
@@ -37,7 +37,7 @@ var PowerShell = &MultiHardenInterfaces{
 	shortName:       "PowerShell",
 	longName:        "Powershell and cmd.exe",
 	description:     "Disables Powershell, Powershell ISE and cmd.exe",
-	hardenByDefault: false,
+	hardenByDefault: true,
 	hardenInterfaces: []HardenInterface{
 		PowerShellDisallowRunMembers{"PowerShell_DisallowRunMembers", "PowerShell_DisallowRunMembers", "PowerShell_DisallowRunMembers", true},
 		&RegistrySingleValueDWORD{

--- a/registry_utils.go
+++ b/registry_utils.go
@@ -27,13 +27,14 @@ import (
 // RegistrySingleValueDWORD is a data type for a single registry DWORD value that suffices for hardening
 // a distinct setting or as part of an RegistryMultiValue
 type RegistrySingleValueDWORD struct {
-	RootKey       registry.Key
-	Path          string
-	ValueName     string
-	HardenedValue uint32
-	shortName     string
-	longName      string
-	description   string
+	RootKey         registry.Key
+	Path            string
+	ValueName       string
+	HardenedValue   uint32
+	shortName       string
+	longName        string
+	description     string
+	hardenByDefault bool
 }
 
 // RegistryMultiValue is a data type for multiple SingleValueDWORDs
@@ -43,6 +44,7 @@ type RegistryMultiValue struct {
 	shortName        string
 	longName         string
 	description      string
+	hardenByDefault  bool
 }
 
 // Harden function for RegistrySingleValueDWORD struct
@@ -89,6 +91,11 @@ func (regValue *RegistrySingleValueDWORD) Description() string {
 	return regValue.description
 }
 
+// HardenByDefault returns if subject should be hardened by default
+func (regValue *RegistrySingleValueDWORD) HardenByDefault() bool {
+	return regValue.hardenByDefault
+}
+
 // Harden function for RegistryMultiValue struct
 func (regMultiValue RegistryMultiValue) Harden(harden bool) error {
 	for _, singleDWORD := range regMultiValue.ArraySingleDWORD {
@@ -127,6 +134,11 @@ func (regMultiValue *RegistryMultiValue) LongName() string {
 // Description of the harden item
 func (regMultiValue *RegistryMultiValue) Description() string {
 	return regMultiValue.description
+}
+
+// HardenByDefault returns if subject should be hardened by default
+func (regMultiValue *RegistryMultiValue) HardenByDefault() bool {
+	return regMultiValue.hardenByDefault
 }
 
 ////

--- a/show_file_extensions.go
+++ b/show_file_extensions.go
@@ -45,6 +45,7 @@ var ShowFileExt = &RegistryMultiValue{
 			shortName:     "ShowFileExt_SuperHidden",
 		},
 	},
-	shortName: "ShowFileExt",
-	longName:  "Show File Extensions",
+	shortName:       "ShowFileExt",
+	longName:        "Show File Extensions",
+	hardenByDefault: true,
 }

--- a/uac.go
+++ b/uac.go
@@ -22,10 +22,11 @@ import (
 
 // UAC contains the registry keys to be hardened
 var UAC = &RegistrySingleValueDWORD{
-	RootKey:       registry.LOCAL_MACHINE,
-	Path:          "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System",
-	ValueName:     "ConsentPromptBehaviorAdmin",
-	HardenedValue: 2,
-	shortName:     "UAC",
-	longName:      "UAC Prompt",
+	RootKey:         registry.LOCAL_MACHINE,
+	Path:            "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System",
+	ValueName:       "ConsentPromptBehaviorAdmin",
+	HardenedValue:   2,
+	shortName:       "UAC",
+	longName:        "UAC Prompt",
+	hardenByDefault: true,
 }

--- a/windows_asr.go
+++ b/windows_asr.go
@@ -34,8 +34,9 @@ More details here:
 import (
 	"errors"
 	"fmt"
-	"golang.org/x/sys/windows/registry"
 	"strings"
+
+	"golang.org/x/sys/windows/registry"
 )
 
 var ruleIDArray = []string{"BE9BA2D9-53EA-4CDC-84E5-9B1EEEE46550", //Block executable content from email client and webmail
@@ -52,16 +53,18 @@ var actionsEnumeration = strings.Join(actionsArray, ",")
 
 // WindowsASRStruct ist the struct for HardenInterface implementation
 type WindowsASRStruct struct {
-	shortName   string
-	longName    string
-	description string
+	shortName       string
+	longName        string
+	description     string
+	hardenByDefault bool
 }
 
 // WindowsASR contains Names for Windows ASR implementation of hardenInterface
 var WindowsASR = &WindowsASRStruct{
-	shortName:   "WindowsASR",
-	longName:    "Windows ASR (needs Win 10/1709)",
-	description: "Windows Attack Surface Reduction (ASR) (needs Win 10/1709)",
+	shortName:       "WindowsASR",
+	longName:        "Windows ASR (needs Win 10/1709)",
+	description:     "Windows Attack Surface Reduction (ASR) (needs Win 10/1709)",
+	hardenByDefault: true,
 }
 
 // Harden method
@@ -207,6 +210,11 @@ func (asr WindowsASRStruct) LongName() string {
 // Description returns description
 func (asr WindowsASRStruct) Description() string {
 	return asr.description
+}
+
+// HardenByDefault returns if subject should be hardened by default
+func (asr WindowsASRStruct) HardenByDefault() bool {
+	return asr.hardenByDefault
 }
 
 // checkWindowsVersion checks if hardentools is running on Windows 10 with Patch Level >= 1709

--- a/wsh.go
+++ b/wsh.go
@@ -22,11 +22,12 @@ import (
 
 // WSH contains registry keys for Windows Script Host Settings
 var WSH = &RegistrySingleValueDWORD{
-	RootKey:       registry.CURRENT_USER,
-	Path:          "SOFTWARE\\Microsoft\\Windows Script Host\\Settings",
-	ValueName:     "Enabled",
-	HardenedValue: 0,
-	shortName:     "WSH",
-	longName:      "Windows Script Host",
-	description:   "Windows Script Host",
+	RootKey:         registry.CURRENT_USER,
+	Path:            "SOFTWARE\\Microsoft\\Windows Script Host\\Settings",
+	ValueName:       "Enabled",
+	HardenedValue:   0,
+	shortName:       "WSH",
+	longName:        "Windows Script Host",
+	description:     "Windows Script Host",
+	hardenByDefault: true,
 }


### PR DESCRIPTION
Every harden object must now supply a method HardenByDefault() that tells if it should he hardened by default (or only optional). Currently all modules are enabled by default.