### PR TITLE
UAC with password prompt and cleanup of legacy restore functionality

### DIFF
--- a/main.go
+++ b/main.go
@@ -158,7 +158,7 @@ func restoreAll() {
 	// Use goroutine to allow gui to update window.
 	go func() {
 		triggerAll(false)
-		restoreSavedRegistryKeys()
+		restoreSavedRegistryKeys() // TODO: add error handling/visibility to user
 		markStatus(false)
 		showStatus(false)
 

--- a/registry_utils.go
+++ b/registry_utils.go
@@ -1,5 +1,5 @@
 // Hardentools
-// Copyright (C) 2017-2020 Security Without Borders
+// Copyright (C) 2017-2021 Security Without Borders
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -53,7 +53,8 @@ type RegistryMultiValue struct {
 func (regValue *RegistrySingleValueDWORD) Harden(harden bool) error {
 	if harden == false {
 		// Restore.
-		return restoreKey(regValue.RootKey, regValue.Path, regValue.ValueName)
+		// don't do anything here since this is done by restoreSavedRegistryKeys()
+		// in the main procedure
 	}
 
 	// else: Harden.
@@ -282,7 +283,7 @@ func saveOriginalRegistryDWORD(rootKey registry.Key, keyName string, valueName s
 // Helper method for restoring original state of a DWORD registry key.
 // TODO: remove this method and replace with restoreSavedRegistryKeys
 //       in future version (see inline comment)
-func restoreKey(rootKey registry.Key, keyName string, valueName string) (err error) {
+/*func restoreKey(rootKey registry.Key, keyName string, valueName string) (err error) {
 	// Open key to be restored.
 	key, err := registry.OpenKey(rootKey, keyName, registry.ALL_ACCESS)
 	if err != nil {
@@ -307,7 +308,7 @@ func restoreKey(rootKey registry.Key, keyName string, valueName string) (err err
 		err = key.DeleteValue(valueName)
 	}
 	return err
-}
+}*/
 
 // Helper method for restoring registry key from saved state.
 func retrieveOriginalRegistryDWORD(rootKey registry.Key, keyName string, valueName string) (value uint32, err error) {

--- a/registry_utils.go
+++ b/registry_utils.go
@@ -55,6 +55,7 @@ func (regValue *RegistrySingleValueDWORD) Harden(harden bool) error {
 		// Restore.
 		// don't do anything here since this is done by restoreSavedRegistryKeys()
 		// in the main procedure
+		return true
 	}
 
 	// else: Harden.

--- a/registry_utils.go
+++ b/registry_utils.go
@@ -55,7 +55,7 @@ func (regValue *RegistrySingleValueDWORD) Harden(harden bool) error {
 		// Restore.
 		// don't do anything here since this is done by restoreSavedRegistryKeys()
 		// in the main procedure
-		return true
+		return nil
 	}
 
 	// else: Harden.

--- a/uac.go
+++ b/uac.go
@@ -1,5 +1,5 @@
 // Hardentools
-// Copyright (C) 2017-2020 Security Without Borders
+// Copyright (C) 2017-2021 Security Without Borders
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -20,13 +20,38 @@ import (
 	"golang.org/x/sys/windows/registry"
 )
 
-// UAC contains the registry keys to be hardened.
-var UAC = &RegistrySingleValueDWORD{
-	RootKey:         registry.LOCAL_MACHINE,
-	Path:            "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System",
-	ValueName:       "ConsentPromptBehaviorAdmin",
-	HardenedValue:   2,
+var UAC = &MultiHardenInterfaces{
+	hardenInterfaces: []HardenInterface{
+		&RegistrySingleValueDWORD{
+			RootKey:         registry.LOCAL_MACHINE,
+			Path:            "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System",
+			ValueName:       "ConsentPromptBehaviorAdmin",
+			HardenedValue:   3,
+			shortName:       "UAC Prompt",
+			longName:        "UAC Prompt",
+			hardenByDefault: true,
+		},
+		&RegistrySingleValueDWORD{
+			RootKey:         registry.LOCAL_MACHINE,
+			Path:            "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System",
+			ValueName:       "PromptOnSecureDesktop",
+			HardenedValue:   1,
+			shortName:       "UAC SecureDesktop",
+			longName:        "UAC PromptOnSecureDesktop",
+			hardenByDefault: true,
+		},
+		&RegistrySingleValueDWORD{
+			RootKey:         registry.LOCAL_MACHINE,
+			Path:            "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System",
+			ValueName:       "EnableLUA",
+			HardenedValue:   1,
+			shortName:       "UAC EnableLUA",
+			longName:        "UAC EnableLUA",
+			hardenByDefault: true,
+		},
+	},
 	shortName:       "UAC",
-	longName:        "UAC Prompt",
+	longName:        "User Account Control",
+	description:     "Enables UAC with secure desktop and admin password",
 	hardenByDefault: true,
 }


### PR DESCRIPTION
Changes:
- UAC with password prompt now (see #46)
- makes sure that all other UAC registry settings are set correctly (which they are by default)
- removed functionality in "restore" that deleted registry keys which have not been saved during harden. If you hardened your system with a (really) old version of hardentools, best first restore with an older version (<= 2.1) and then harden with this version again.

Still needs some testing -> so would publish a new alpha version.